### PR TITLE
Adding two more necessary header files to include directory in build …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,10 +14,10 @@ configure_file (${CMAKE_SOURCE_DIR}/include/fenix-config.h.in
 configure_file(${CMAKE_SOURCE_DIR}/include/fenix.h
   "${CMAKE_BINARY_DIR}/include/fenix.h" COPYONLY)
 
-configure_file(${CMAKE_SOURCE_DIR}/include/fenix.h
+configure_file(${CMAKE_SOURCE_DIR}/include/fenix_constants.h
   "${CMAKE_BINARY_DIR}/include/fenix_constants.h" COPYONLY)
 
-configure_file(${CMAKE_SOURCE_DIR}/include/fenix.h
+configure_file(${CMAKE_SOURCE_DIR}/include/fenix_process_recovery.h
   "${CMAKE_BINARY_DIR}/include/fenix_process_recovery.h" COPYONLY)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,12 @@ configure_file (${CMAKE_SOURCE_DIR}/include/fenix-config.h.in
 configure_file(${CMAKE_SOURCE_DIR}/include/fenix.h
   "${CMAKE_BINARY_DIR}/include/fenix.h" COPYONLY)
 
+configure_file(${CMAKE_SOURCE_DIR}/include/fenix.h
+  "${CMAKE_BINARY_DIR}/include/fenix_constants.h" COPYONLY)
+
+configure_file(${CMAKE_SOURCE_DIR}/include/fenix.h
+  "${CMAKE_BINARY_DIR}/include/fenix_process_recovery.h" COPYONLY)
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set (Fenix_SOURCES 


### PR DESCRIPTION
…tree
fenix.h includes two fenix-specific header files, which themselves do not include more fenix-specific header files. the Cmake list had to be modified to add those header files to the build tree. I tried this and it worked for the PRKs.