### PR TITLE
More reliable MCA parameters in CI tests

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -41,6 +41,9 @@ services:
                 -DBUILD_TESTING=ON \
                 -DMPIEXEC_PREFLAGS="--allow-run-as-root;--map-by;:oversubscribe" && \
             make -j
+
+        ENV OMPI_MCA_coll=^han
+        ENV OMPI_MCA_btl=tcp,sm,self
         
         WORKDIR /fenix/build
         ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
These should hopefully fix our intermittent test failures. Other BTLs are probably not being built, but the han collectives module is not currently fault tolerant.