### PR TITLE
Test against fixed OMPI versions

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -39,7 +39,7 @@ services:
                 -DCMAKE_C_COMPILER=mpicc \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DMPIEXEC_PREFLAGS="--allow-run-as-root;--map-by;:oversubscribe" && \
+                -DMPIEXEC_PREFLAGS="--allow-run-as-root;--map-by;:oversubscribe;--mca;async_mpi_finalize;1" && \
             make -j
 
         ENV OMPI_MCA_coll=^han
@@ -47,7 +47,7 @@ services:
         
         WORKDIR /fenix/build
         ENTRYPOINT ["/entrypoint.sh"]
-        CMD ["ctest", "--output-on-failure", "--timeout", "60"]
+        CMD ["ctest", "--output-on-failure", "--timeout", "20"]
       args:
         OMPI_VERSION: main
     pull_policy: build

--- a/.github/workflows/ci_checks.yaml
+++ b/.github/workflows/ci_checks.yaml
@@ -38,4 +38,4 @@ jobs:
             *.args.OMPI_VERSION=${{ matrix.ompi_version }}
 
       - name: Test Fenix
-        run: docker run fenix ctest --output-on-failure --timeout 20 --repeat until-fail:5
+        run: docker run fenix ctest -V --timeout 20 --repeat until-fail:5

--- a/.github/workflows/ci_checks.yaml
+++ b/.github/workflows/ci_checks.yaml
@@ -11,10 +11,8 @@ jobs:
       matrix:
         ompi_version:
           - main
-          - 5.0.3
-          - git.v5.0.5
-          - git.v5.0.7
           - git.v5.0.x
+          - git.v6.0.x
 
     steps:
       - name: Checkout
@@ -40,4 +38,4 @@ jobs:
             *.args.OMPI_VERSION=${{ matrix.ompi_version }}
 
       - name: Test Fenix
-        run: docker run fenix ctest --output-on-failure --timeout 20 --repeat after-timeout:3
+        run: docker run fenix ctest --output-on-failure --timeout 20

--- a/.github/workflows/ci_checks.yaml
+++ b/.github/workflows/ci_checks.yaml
@@ -38,4 +38,4 @@ jobs:
             *.args.OMPI_VERSION=${{ matrix.ompi_version }}
 
       - name: Test Fenix
-        run: docker run fenix ctest --output-on-failure --timeout 20
+        run: docker run fenix ctest --output-on-failure --timeout 20 --repeat until-fail:5

--- a/test/failed_spares/fenix_failed_spares.c
+++ b/test/failed_spares/fenix_failed_spares.c
@@ -66,7 +66,7 @@
 const int kKillID = 1;
 
 void* exitThread(void* should_exit){
-    sleep(1);
+    usleep(10000);
     if( ((intptr_t)should_exit) == 1){
         pid_t pid = getpid();
         kill(pid, SIGTERM);
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
 
   if (recovered == 0) {
     //Give time for exit thread to work (which needed to give time for fenix init)
-    sleep(2);
+    usleep(100000);
   }
 
   MPI_Barrier(new_comm);


### PR DESCRIPTION
Testing against these versions (and any future releases past v5.0.9) will hopefully resolve our CI issues. Dropping the repeat-after-timeouts functionality from the testing, since it will hopefully no longer be needed.