### PR TITLE
Unified error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ option(BUILD_TESTING     "Builds tests and test modes of files"                O
 option(BUILD_DOCS        "Builds documentation if is doxygen found"            ON)
 option(DOCS_ONLY         "Only build documentation"                            OFF)
 
+option(FENIX_C_CATCH_RUNTIME_EXCEPTIONS
+    "Catch runtime exceptions and return an error code in the C API" OFF)
+option(FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS
+    "Catch runtime exceptions and return an error code in the C++ API" OFF)
+
 #Solves an issue with some system environments putting their MPI headers before
 #the headers CMake includes. Forces non-system MPI headers when incorrect headers
 #detected in include path.

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -104,7 +104,9 @@ typedef enum {
     FENIX_ERROR_INVALID_GROUPID,
     FENIX_ERROR_INVALID_MEMBERID,
     FENIX_ERROR_INVALID_LOGIC_CALL,
+    FENIX_ERROR_INVALID_POLICY_NAME,
     FENIX_ERROR_INVALID_TIMESTAMP,
+    FENIX_ERROR_INVALID_TIMESTART,
     FENIX_ERROR_INVALID_DEPTH,
     FENIX_ERROR_INVALID_ATTRIBUTE_NAME,
     FENIX_ERROR_INVALID_ATTRIBUTE_VALUE,
@@ -299,8 +301,9 @@ int Fenix_Callback_pop();
 
 /**
  * @brief Invoke all callbacks with information from the last recovered fault
+ * @returnstatus
  */
-void Fenix_Callback_invoke_all();
+int Fenix_Callback_invoke_all();
 
 /**
  * @brief Check for any failed ranks

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -134,7 +134,7 @@ int callback_register(
 int callback_pop(CallbackLocation loc = POST_RECOVERY);
 
 //@!brief Overload of #Fenix_Callback_invoke_all
-void callback_invoke_all(CallbackLocation loc = POST_RECOVERY);
+int callback_invoke_all(CallbackLocation loc = POST_RECOVERY);
 
 /**
  * @brief Get the failed ranks from the most recent recovery

--- a/include/fenix_data_group.hpp
+++ b/include/fenix_data_group.hpp
@@ -57,23 +57,23 @@
 #define __FENIX_DATA_GROUP_H__
 
 #include <map>
+#include <source_location>
 
 #include <mpi.h>
 #include "fenix.h"
 #include "fenix_data_member.hpp"
-#include "fenix_util.hpp"
 #include "fenix_data_subset.hpp"
 
 #define __FENIX_DEFAULT_GROUP_SIZE 32
 
 namespace fenix::data {
 
-using member_iterator = std::pair<int, fenix_member_entry_t*>;
-
 //We keep basic bookkeeping info here, policy specific
 //information is kept by the policy's data type.
 struct fenix_group_t {
-    using member_iterator = fenix::data::member_iterator;
+    fenix_group_t(
+        int groupid, MPI_Comm c, int timestart, int depth, int policy
+    );
 
     int groupid;
     MPI_Comm comm;
@@ -86,14 +86,19 @@ struct fenix_group_t {
     std::map<int, fenix_member_entry_t> members;
 
     std::vector<int> get_member_ids();
-    //Search for id, returning {-1, nullptr} if not found.
-    member_iterator search_member(int id);
-    //As search_member, but print an error message if id not found.
-    member_iterator find_member(int id);
+    //Search for id, returning null if not found.
+    fenix_member_entry_t* search_member(int id);
+    //As search_member, but throw if not found
+    fenix_member_entry_t* find_member(
+        int id, std::source_location loc = std::source_location::current()
+    );
+    int member_create(int id, void* data, int count, MPI_Datatype datatype);
+    int member_create(int id, void* data, int count, int datatype_size);
+    int member_delete(int memberid);
     
     virtual int group_delete() = 0;
     virtual int member_create(fenix_member_entry_t* member) = 0;
-    virtual int member_delete(int memberid) = 0;
+    virtual int member_delete(fenix_member_entry_t* member) = 0;
     virtual int get_redundant_policy(int* name, void* value, int* flag) = 0;
     virtual int member_store(int memberid, const DataSubset& subset) = 0;
     virtual int member_storev(int memberid, const DataSubset& subset) = 0;
@@ -128,6 +133,7 @@ typedef struct __group_entry_packet {
 
 fenix_data_recovery_t * __fenix_data_recovery_init();
 
+int __fenix_data_recovery_remove_group(int groupid);
 void __fenix_data_recovery_destroy( fenix_data_recovery_t *fx_data_recovery );
 
 void __fenix_ensure_data_recovery_capacity( fenix_data_recovery_t *dr);
@@ -136,12 +142,10 @@ int __fenix_search_groupid( int key, fenix_data_recovery_t *dr);
 
 int __fenix_find_next_group_position( fenix_data_recovery_t *dr );
 
-using group_iterator = std::pair<int, fenix_group_t*>;
-
-group_iterator search_group(int id, fenix_data_recovery_t *dr);
-group_iterator search_group(int id);
-group_iterator find_group(int id, fenix_data_recovery_t *dr);
-group_iterator find_group(int id);
+fenix_group_t* search_group(int id);
+fenix_group_t* find_group(
+    int id, std::source_location loc = std::source_location::current()
+);
 
 } //end namespace fenix::data
 

--- a/include/fenix_data_member.hpp
+++ b/include/fenix_data_member.hpp
@@ -56,9 +56,6 @@
 #ifndef __FENIX_DATA_MEMBER_H__
 #define __FENIX_DATA_MEMBER_H__
 
-#include <mpi.h>
-#include "fenix_util.hpp"
-
 #define __FENIX_DEFAULT_MEMBER_SIZE 512
 namespace fenix::data {
 
@@ -72,20 +69,16 @@ struct fenix_member_entry_packet_t {
 
 struct fenix_member_entry_t {
     fenix_member_entry_t() = default;
+    fenix_member_entry_t(int id, void* data, int count, MPI_Datatype datatype);
+    fenix_member_entry_t(int id, void* data, int count, int datatype_size);
 
     fenix_member_entry_packet_t to_packet();
 
     int memberid = -1;
-    enum states state;
     char *user_data = nullptr;
-    int datatype_size;
     int current_count;
+    int datatype_size;
 };
-
-fenix_member_entry_t* __fenix_data_member_add_entry(fenix_group_t* group,
-        int memberid, void* data, int count, int datatype_size);
-
-int __fenix_search_memberid(fenix_group_t* group, int memberid);
 
 } // namespace fenix::data
 #endif // FENIX_DATA_MEMBER_H

--- a/include/fenix_data_policy.hpp
+++ b/include/fenix_data_policy.hpp
@@ -63,8 +63,10 @@
 
 namespace fenix::data {
 
-int __fenix_policy_get_group(fenix_group_t** group, MPI_Comm comm, 
-      int timestart, int depth, int policy_name, void* policy_value, int* flag);
+fenix_group_t* new_group(
+  int groupid, MPI_Comm comm, int timestart, int depth, int policy_name,
+  void* policy_value, int* flag
+);
 
 } // namespace fenix::data
 

--- a/include/fenix_data_policy_in_memory_raid.hpp
+++ b/include/fenix_data_policy_in_memory_raid.hpp
@@ -69,9 +69,6 @@
 
 namespace fenix::data::imr {
 
-void __fenix_policy_in_memory_raid_get_group(fenix_group_t** group, MPI_Comm comm,
-      int timestart, int depth, void* policy_value, int* flag);
-
 struct Entry {
   //No copying, must be moved
   Entry(const Entry&) = delete;
@@ -165,7 +162,9 @@ struct ParityMember : public Member {
 };
 
 struct Group : public fenix_group_t {
-  Group(MPI_Comm comm, int timestart, int depth, int* policy, int* flag);
+  Group(
+    int id, MPI_Comm comm, int timestart, int depth, int* policy, int* flag
+  );
 
   int mode;
   int rank_separation;
@@ -190,7 +189,7 @@ struct Group : public fenix_group_t {
 
   int group_delete() override;
   int member_create(fenix_member_entry_t* mentry) override;
-  int member_delete(int member_id) override;
+  int member_delete(fenix_member_entry_t* mentry) override;
   int get_redundant_policy(int* name, void* value, int* flag) override;
 
   int member_store(int member_id, const DataSubset& subset) override;

--- a/include/fenix_exception.hpp
+++ b/include/fenix_exception.hpp
@@ -59,16 +59,72 @@
 
 #include <mpi.h>
 #include <exception>
+#include <source_location>
+#include <string_view>
+#include <string>
 
 namespace fenix {
 
 struct CommException : public std::exception {
-    MPI_Comm repaired_comm;
-    const int fenix_err;
-    CommException(MPI_Comm comm, int err) :
-        repaired_comm(comm), fenix_err(err) { };
+  CommException(MPI_Comm comm, int err)
+    : repaired_comm(comm), fenix_err(err) {};
+    
+  MPI_Comm repaired_comm;
+  const int fenix_err;
+};
+
+struct RuntimeException : public std::exception {
+  using Location = std::source_location;
+
+  RuntimeException(Location l = Location::current())
+    : RuntimeException(FENIX_ERROR_NOCATEGORY, "FENIX_ERROR_NOCATEGORY", l) {}
+
+  RuntimeException(const char* e_str, Location l = Location::current())
+    : RuntimeException(FENIX_ERROR_NOCATEGORY, e_str, l) {};
+
+  // Helper for preprocessor macro
+  RuntimeException(
+    const char* e_str, const char*, Location l = Location::current()
+  ) : RuntimeException(FENIX_ERROR_NOCATEGORY, e_str, l) {};
+
+  RuntimeException(int e, const char* e_str, Location l = Location::current())
+    : error(e), error_string(e_str), location(l) {};
+
+  // file:line function error_string
+  std::string to_string(int depth = 0) const noexcept {
+    std::string_view f = location.file_name();
+    std::string l = std::to_string(location.line());
+    std::string_view fn = location.function_name();
+
+    std::string ret;
+    ret.reserve(
+      3 + depth * 2 + f.size() + l.size() + fn.size() + error_string.size()
+    );
+    ret.assign(" ", depth * 2);
+    ret += f;  ret += ":";
+    ret += l;  ret += " ";
+    ret += fn; ret += " ";
+    ret += error_string;
+    return ret;
+  }
+
+  const char* what() const noexcept override {
+    m_string = to_string();
+    return m_string.c_str();
+  }
+
+  const int error;
+  const std::string_view error_string;
+  const std::source_location location;
+
+ private:
+  mutable std::string m_string;
 };
 
 } // namespace fenix
+
+// err can be a FENIX_ERROR_* value, or any string
+#define FENIX_THROW(err) throw fenix::RuntimeException(err, #err)
+#define FENIX_THROW_FROM(err, loc) throw fenix::RuntimeException(err, #err, loc)
 
 #endif

--- a/include/fenix_ext.hpp
+++ b/include/fenix_ext.hpp
@@ -75,7 +75,7 @@ typedef struct {
     ResumeMode resume_mode = JUMP;
     CallbackExceptionMode callback_exception_mode = RETHROW;
     UnhandledMode unhandled_mode = ABORT;
-    int ignore_errs = false;       // Temporarily ignore all errors & recovery
+    bool ignore_errs = false;       // Temporarily ignore all errors & recovery
     int spawn_policy;             // Indicate dynamic process spawning
     jmp_buf *recover_environment; // Calling environment to fill the jmp_buf structure
 

--- a/include/fenix_util.hpp
+++ b/include/fenix_util.hpp
@@ -74,6 +74,10 @@
 #include <signal.h>
 #include <libgen.h>
 
+#include <cassert>
+
+#include "fenix_ext.hpp"
+
 extern char *logname;
 
 #define LDEBUG(f...)  {LLIND("debug",f);}
@@ -81,8 +85,6 @@ extern char *logname;
 #define ERRHANDLE(f...){LFATAL(f);}
 #define LFATAL(f...)  {LLINF("fatal", f);}
 #define LLINF(t,f...) {fprintf(stderr,"(%i): %s: ", getpid(), t); fprintf(stderr, f);}
-
-enum states { EMPTY = 0, OCCUPIED = 1, DELETED = 2, NEEDFIX = 3 };
 
 void __fenix_ranks_agree(int *, int *, int *, MPI_Datatype *);
 
@@ -111,5 +113,86 @@ void *s_calloc(int count, size_t size);
 void *s_malloc(size_t size);
 
 void *s_realloc(void *mem, size_t size);
+
+
+namespace fenix::util {
+
+inline int comm_size(MPI_Comm c) {
+  int ret;
+  MPI_Comm_size(c, &ret);
+  return ret;
+}
+inline int comm_rank(MPI_Comm c) {
+  int ret;
+  MPI_Comm_rank(c, &ret);
+  return ret;
+}
+
+// ScopedSetting struct holds the old value and automatically reverts in
+// destructor, so settings changes revert even when exceptions are thrown.
+template<typename T>
+struct ScopedSetting {
+  ScopedSetting(T& m_setting, T val) : setting(m_setting) { setting = val; }
+  ~ScopedSetting() { setting = old_val; }
+ private:
+  T& setting;
+  const T old_val = setting;
+};
+
+struct ScopedIgnoreErrs : public ScopedSetting<bool> {
+  ScopedIgnoreErrs(bool ignore_errs)
+    : ScopedSetting(fenix_rt.ignore_errs, ignore_errs) {}
+};
+struct ScopedResumeMode : public ScopedSetting<ResumeMode> {
+  ScopedResumeMode(ResumeMode resume_mode)
+    : ScopedSetting(fenix_rt.resume_mode, resume_mode) {}
+};
+struct ScopedUnhandledMode : public ScopedSetting<UnhandledMode> {
+  ScopedUnhandledMode(UnhandledMode unhandled_mode)
+    : ScopedSetting(fenix_rt.unhandled_mode, unhandled_mode) {}
+};
+
+// Default error handling for inside the Fenix runtime.
+struct ScopedDefaultRuntimeSettings {
+  const ScopedIgnoreErrs    ignore_errs{ false };
+  const ScopedResumeMode    resume_mode{ THROW };
+  const ScopedUnhandledMode unhandled_mode{ ABORT };
+};
+} // namespace fenix::util
+
+#define RUNTIME_EXCEPTION_HANDLER              \
+  } catch (const fenix::RuntimeException& e) { \
+    debug_print("%s\n", e.what());             \
+    return e.error;
+
+#define COMM_EXCEPTION_HANDLER                                     \
+  } catch (const fenix::CommException& e) {                        \
+    switch(fenix_rt.resume_mode) {                                 \
+      case fenix::JUMP: longjmp(*fenix_rt.recover_environment, 1); \
+      case fenix::THROW: throw;                                    \
+      case fenix::RETURN:                                          \
+      default: break;                                              \
+    }                                                              \
+    return FENIX_ERROR_CANCELLED;                                  \
+  }
+
+#define FENIX_CPP_API_BEGIN                                \
+  try {                                                    \
+    fenix::util::ScopedDefaultRuntimeSettings _scoped_drs; \
+    assert(fenix_rt.fenix_init_flag);
+
+#define FENIX_C_API_BEGIN FENIX_CPP_API_BEGIN
+
+#ifdef FENIX_C_CATCH_RUNTIME_EXCEPTIONS
+#define FENIX_C_API_END RUNTIME_EXCEPTION_HANDLER COMM_EXCEPTION_HANDLER
+#else
+#define FENIX_C_API_END COMM_EXCEPTION_HANDLER
+#endif
+
+#ifdef FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS
+#define FENIX_CPP_API_END RUNTIME_EXCEPTION_HANDLER COMM_EXCEPTION_HANDLER
+#else
+#define FENIX_CPP_API_END COMM_EXCEPTION_HANDLER
+#endif
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,13 @@ target_include_directories(fenix
         $<INSTALL_INTERFACE:include>
     PRIVATE "${CMAKE_SOURCE_DIR}/src")
 
+if(FENIX_C_CATCH_RUNTIME_EXCEPTIONS)
+    target_compile_definitions(fenix PUBLIC FENIX_C_CATCH_RUNTIME_EXCEPTIONS)
+endif()
+if(FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS)
+    target_compile_definitions(fenix PUBLIC FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS)
+endif()
+
 install(TARGETS fenix
     EXPORT fenix
     ARCHIVE DESTINATION lib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ set (Fenix_SOURCES
 
 add_library(fenix STATIC ${Fenix_SOURCES})
 
-target_compile_features(fenix PRIVATE cxx_std_17)
+target_compile_features(fenix PUBLIC cxx_std_20)
 
 target_link_libraries(fenix PUBLIC MPI::MPI_CXX)
 

--- a/src/fenix.cpp
+++ b/src/fenix.cpp
@@ -62,95 +62,111 @@
 using namespace fenix;
 using namespace fenix::data;
 
-const Fenix_Data_subset  FENIX_DATA_SUBSET_FULL = { new DataSubset(DataSubset::MAX) };
-const Fenix_Data_subset  FENIX_DATA_SUBSET_EMPTY = { new DataSubset() };
+const Fenix_Data_subset FENIX_DATA_SUBSET_FULL = {
+  new DataSubset(DataSubset::MAX)
+};
+const Fenix_Data_subset FENIX_DATA_SUBSET_EMPTY = {new DataSubset()};
 Fenix_Data_subset* FENIX_DATA_SUBSET_IGNORE = NULL;
 
 int Fenix_Callback_register(
-    void (*recover)(MPI_Comm, int, void *), void *callback_data
+  void (*recover)(MPI_Comm, int, void*), void* callback_data
 ) {
-    return callback_register(
-        [recover, callback_data](MPI_Comm comm, int fenix_error){
-            recover(comm, fenix_error, callback_data);
-        }
-    );
+  FENIX_C_API_BEGIN
+  return callback_register([recover,
+                            callback_data](MPI_Comm comm, int fenix_error) {
+    recover(comm, fenix_error, callback_data);
+  });
+  FENIX_C_API_END
 }
 
 int Fenix_Callback_pop() {
-    return callback_pop();
+  FENIX_C_API_BEGIN
+  return callback_pop();
+  FENIX_C_API_END
 }
 
-void Fenix_Callback_invoke_all() {
-    callback_invoke_all();
+int Fenix_Callback_invoke_all() {
+  FENIX_C_API_BEGIN
+  return callback_invoke_all();
+  FENIX_C_API_END
 }
 
-int Fenix_Initialized(int *flag) {
-    *flag = (fenix_rt.fenix_init_flag) ? 1 : 0;
-    return FENIX_SUCCESS;
+int Fenix_Initialized(int* flag) {
+  *flag = (fenix_rt.fenix_init_flag) ? 1 : 0;
+  return FENIX_SUCCESS;
 }
 
 int Fenix_Process_fail_list(int** fail_list) {
-    *fail_list = fenix_rt.fail_world;
-    return fenix_rt.fail_world_size;
+  FENIX_C_API_BEGIN
+  *fail_list = fenix_rt.fail_world;
+  return fenix_rt.fail_world_size;
+  FENIX_C_API_END
 }
 
-int Fenix_check_cancelled(MPI_Request *request, MPI_Status *status) {
-    // We know this may return as "COMM_REVOKED", but we know the error was
-    // already handled
-    int old_ignore_setting = fenix_rt.ignore_errs;
-    fenix_rt.ignore_errs = 1;
+int Fenix_check_cancelled(MPI_Request* request, MPI_Status* status) {
+  FENIX_C_API_BEGIN
+  // We know this may return as "COMM_REVOKED", but we know the error was
+  // already handled
+  util::ScopedIgnoreErrs ignore_errs{true};
 
-    int flag;
-    int ret = PMPI_Test(request, &flag, status);
+  int flag;
+  int ret = PMPI_Test(request, &flag, status);
 
-    fenix_rt.ignore_errs = old_ignore_setting;
-
-    // Request was (potentially) cancelled if ret is MPI_ERR_PROC_FAILED
-    return ret == MPI_ERR_PROC_FAILED || ret == MPI_ERR_REVOKED;
+  //Request was (potentially) cancelled if ret is MPI_ERR_PROC_FAILED
+  return ret == MPI_ERR_PROC_FAILED || ret == MPI_ERR_REVOKED;
+  FENIX_C_API_END
 }
 
 int Fenix_Process_detect_failures(int do_recovery) {
-    return detect_failures(do_recovery);
+  FENIX_C_API_BEGIN
+  return detect_failures(do_recovery);
+  FENIX_C_API_END
 }
 
 Fenix_Rank_role Fenix_get_role() {
-    return role();
+  assert(initialized());
+  return role();
 }
 
 int Fenix_get_error() {
-    return error();
+  assert(initialized());
+  return error();
 }
 
 int Fenix_get_nspare() {
-    return nspare();
+  assert(initialized());
+  return nspare();
 }
 
 namespace fenix {
 
 void throw_exception() {
-    throw CommException(*fenix_rt.user_world, *fenix_rt.ret_error);
+  assert(initialized());
+  throw CommException(*fenix_rt.user_world, *fenix_rt.ret_error);
 }
 
 Fenix_Rank_role role() {
-    return (Fenix_Rank_role) fenix_rt.role;
+  assert(initialized());
+  return (Fenix_Rank_role)fenix_rt.role;
 }
 
 int error() {
-    return fenix_rt.repair_result;
+  assert(initialized());
+  return fenix_rt.repair_result;
 }
 
 int nspare() {
-    return fenix_rt.spare_ranks;
+  assert(initialized());
+  return fenix_rt.spare_ranks;
 }
 
 std::vector<int> fail_list() {
-    if(fenix_rt.fail_world_size == 0) return {};
-    return {fenix_rt.fail_world, fenix_rt.fail_world+fenix_rt.fail_world_size};
+  assert(initialized());
+  if (fenix_rt.fail_world_size == 0) return {};
+  return {fenix_rt.fail_world, fenix_rt.fail_world + fenix_rt.fail_world_size};
 }
 
-bool initialized() {
-    return fenix_rt.fenix_init_flag;
-}
+bool initialized() { return fenix_rt.fenix_init_flag; }
 
 namespace data {
 const DataSubset SUBSET_FULL = {{0, fenix::DataSubset::MAX}};
@@ -160,98 +176,159 @@ DataSubset SUBSET_IGNORE = SUBSET_EMPTY;
 
 } //namespace fenix
 
-
 int Fenix_Data_group_create(
-    int group_id, MPI_Comm comm, int start_time_stamp, int depth, int policy,
-    void* policy_args, int* flag
+  int group_id, MPI_Comm comm, int start_time_stamp, int depth, int policy,
+  void* policy_args, int* flag
 ) {
-    return group_create(
-        group_id, comm, start_time_stamp, depth, policy, policy_args, flag
-    );
+  FENIX_C_API_BEGIN
+  return group_create(
+    group_id, comm, start_time_stamp, depth, policy, policy_args, flag
+  );
+  FENIX_C_API_END
 }
 
-int Fenix_Data_member_create( int group_id, int member_id, void *buffer, int count, MPI_Datatype datatype ) {
-    return member_create(group_id, member_id, buffer, count, datatype);
+int Fenix_Data_member_create(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
+) {
+  FENIX_C_API_BEGIN
+  return member_create(group_id, member_id, buffer, count, datatype);
+  FENIX_C_API_END
 }
 
-int Fenix_Data_member_store(int group_id, int member_id, const Fenix_Data_subset subset) {
-    return member_store(group_id, member_id, *(DataSubset*)subset.impl);
+int Fenix_Data_member_store(
+  int group_id, int member_id, const Fenix_Data_subset subset
+) {
+  FENIX_C_API_BEGIN
+  return member_store(group_id, member_id, *(DataSubset*)subset.impl);
+  FENIX_C_API_END
 }
 
-int Fenix_Data_member_storev(int group_id, int member_id, const Fenix_Data_subset subset) {
-    return member_storev(group_id, member_id, *(DataSubset*)subset.impl);
+int Fenix_Data_member_storev(
+  int group_id, int member_id, const Fenix_Data_subset subset
+) {
+  FENIX_C_API_BEGIN
+  return member_storev(group_id, member_id, *(DataSubset*)subset.impl);
+  FENIX_C_API_END
 }
 
-int Fenix_Data_member_istore(int group_id, int member_id, const Fenix_Data_subset subset, Fenix_Request *request) {
-    return member_istore(group_id, member_id, *(DataSubset*)subset.impl, request);
+int Fenix_Data_member_istore(
+  int group_id, int member_id, const Fenix_Data_subset subset,
+  Fenix_Request* request
+) {
+  FENIX_C_API_BEGIN
+  return member_istore(group_id, member_id, *(DataSubset*)subset.impl, request);
+  FENIX_C_API_END
 }
 
-int Fenix_Data_member_istorev(int group_id, int member_id, const Fenix_Data_subset subset, Fenix_Request *request) {
-    return member_istorev(group_id, member_id, *(DataSubset*)subset.impl, request);
+int Fenix_Data_member_istorev(
+  int group_id, int member_id, const Fenix_Data_subset subset,
+  Fenix_Request* request
+) {
+  FENIX_C_API_BEGIN
+  return member_istorev(
+    group_id, member_id, *(DataSubset*)subset.impl, request
+  );
+  FENIX_C_API_END
 }
 
-int Fenix_Data_commit(int group_id, int *time_stamp) {
-    return commit(group_id, time_stamp);
+int Fenix_Data_commit(int group_id, int* time_stamp) {
+  FENIX_C_API_BEGIN
+  return commit(group_id, time_stamp);
+  FENIX_C_API_END
 }
 
-int Fenix_Data_commit_barrier(int group_id, int *time_stamp) {
-    return commit_barrier(group_id, time_stamp);
+int Fenix_Data_commit_barrier(int group_id, int* time_stamp) {
+  FENIX_C_API_BEGIN
+  return commit_barrier(group_id, time_stamp);
+  FENIX_C_API_END
 }
 
 int Fenix_Data_barrier(int group_id) {
-    return 0;
+  FENIX_C_API_BEGIN
+  return 0;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_member_restore(int group_id, int member_id, void *target_buffer, int max_count, int time_stamp, Fenix_Data_subset* data_found) {
-    DataSubset* s = new DataSubset();
-    int ret = member_restore(
-        group_id, member_id, target_buffer, max_count, time_stamp, *s
-    );
-    if(data_found == nullptr){
-        delete s;
-    } else {
-        data_found->impl = s;
-    }
-    return ret;
+int Fenix_Data_member_restore(
+  int group_id, int member_id, void* target_buffer, int max_count,
+  int time_stamp, Fenix_Data_subset* data_found
+) {
+  FENIX_C_API_BEGIN
+  DataSubset* s = new DataSubset();
+  int ret = member_restore(
+    group_id, member_id, target_buffer, max_count, time_stamp, *s
+  );
+  if (data_found == nullptr) {
+    delete s;
+  } else {
+    data_found->impl = s;
+  }
+  return ret;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_member_lrestore(int group_id, int member_id, void *target_buffer, int max_count, int time_stamp, Fenix_Data_subset* data_found) {
-    DataSubset* s = new DataSubset();
-    int ret = member_lrestore(
-        group_id, member_id, target_buffer, max_count, time_stamp, *s
-    );
-    if(data_found == nullptr){
-        delete s;
-    } else {
-        data_found->impl = s;
-    }
-    return ret;
+int Fenix_Data_member_lrestore(
+  int group_id, int member_id, void* target_buffer, int max_count,
+  int time_stamp, Fenix_Data_subset* data_found
+) {
+  FENIX_C_API_BEGIN
+  DataSubset* s = new DataSubset();
+  int ret = member_lrestore(
+    group_id, member_id, target_buffer, max_count, time_stamp, *s
+  );
+  if (data_found == nullptr) {
+    delete s;
+  } else {
+    data_found->impl = s;
+  }
+  return ret;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_subset_create(int num_blocks, int start_offset, int end_offset, int stride, Fenix_Data_subset *subset_specifier) {
-    subset_specifier->impl = new DataSubset({start_offset, end_offset}, num_blocks, stride);
-    return FENIX_SUCCESS;
+int Fenix_Data_subset_create(
+  int num_blocks, int start_offset, int end_offset, int stride,
+  Fenix_Data_subset* subset_specifier
+) {
+  FENIX_C_API_BEGIN
+  subset_specifier->impl =
+    new DataSubset({start_offset, end_offset}, num_blocks, stride);
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_subset_createv(int num_blocks, int *array_start_offsets, int *array_end_offsets, Fenix_Data_subset *subset_specifier) {
-    subset_specifier->impl = new DataSubset(num_blocks, array_start_offsets, array_end_offsets);
-    return FENIX_SUCCESS;
+int Fenix_Data_subset_createv(
+  int num_blocks, int* array_start_offsets, int* array_end_offsets,
+  Fenix_Data_subset* subset_specifier
+) {
+  FENIX_C_API_BEGIN
+  subset_specifier->impl =
+    new DataSubset(num_blocks, array_start_offsets, array_end_offsets);
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_subset_delete(Fenix_Data_subset *subset_specifier) {
-    delete (DataSubset*) subset_specifier->impl;
-    subset_specifier->impl = nullptr;
-    return FENIX_SUCCESS;
+int Fenix_Data_subset_delete(Fenix_Data_subset* subset_specifier) {
+  FENIX_C_API_BEGIN
+  delete (DataSubset*)subset_specifier->impl;
+  subset_specifier->impl = nullptr;
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
 }
 
 int Fenix_Data_snapshot_delete(int group_id, int time_stamp) {
-    return snapshot_delete(group_id, time_stamp);
+  FENIX_C_API_BEGIN
+  return snapshot_delete(group_id, time_stamp);
+  FENIX_C_API_END
 }
 
 int Fenix_Data_group_delete(int group_id) {
-    return group_delete(group_id);
+  FENIX_C_API_BEGIN
+  return group_delete(group_id);
+  FENIX_C_API_END
 }
 
 int Fenix_Data_member_delete(int group_id, int member_id) {
-    return member_delete(group_id, member_id);
+  FENIX_C_API_BEGIN
+  return member_delete(group_id, member_id);
+  FENIX_C_API_END
 }

--- a/src/fenix_callbacks.cpp
+++ b/src/fenix_callbacks.cpp
@@ -61,55 +61,60 @@
 #include "fenix_exception.hpp"
 #include <mpi.h>
 
-
 namespace fenix {
 
-static std::vector<FenixCallbackFunc>& callbacks(CallbackLocation loc){
-    return fenix_rt.callbacks.try_emplace(loc).first->second;
+static std::vector<FenixCallbackFunc>& callbacks(CallbackLocation loc) {
+  return fenix_rt.callbacks.try_emplace(loc).first->second;
 }
 
-int callback_register(FenixCallbackFunc recover, CallbackLocation loc)
-{
-    if(!fenix_rt.fenix_init_flag) return FENIX_ERROR_UNINITIALIZED;
+int callback_register(FenixCallbackFunc recover, CallbackLocation loc) {
+  FENIX_CPP_API_BEGIN
+  if (!fenix_rt.fenix_init_flag) return FENIX_ERROR_UNINITIALIZED;
 
-    callbacks(loc).push_back(recover);
+  callbacks(loc).push_back(recover);
 
-    return FENIX_SUCCESS;
+  return FENIX_SUCCESS;
+  FENIX_CPP_API_END
 }
 
-int callback_pop(CallbackLocation loc){
-   if(!fenix_rt.fenix_init_flag) return FENIX_ERROR_UNINITIALIZED;
-   if(callbacks(loc).empty()) return FENIX_ERROR_CALLBACK_NOT_REGISTERED;
+int callback_pop(CallbackLocation loc) {
+  FENIX_CPP_API_BEGIN
+  if (!fenix_rt.fenix_init_flag) return FENIX_ERROR_UNINITIALIZED;
+  if (callbacks(loc).empty()) return FENIX_ERROR_CALLBACK_NOT_REGISTERED;
 
-   callbacks(loc).pop_back();
+  callbacks(loc).pop_back();
 
-   return FENIX_SUCCESS;
+  return FENIX_SUCCESS;
+  FENIX_CPP_API_END
 }
 
-void callback_invoke_all(CallbackLocation loc){
-    //If callbacks are invoked in a nested manner due to caught exceptions
-    //within a callback, we want to only finish the most recent call. All prior
-    //calls should exit as soon as control returns.
-    static int callbacks_depth = 0;
-    int m_callbacks_layer = callbacks_depth++;
+int callback_invoke_all(CallbackLocation loc) {
+  FENIX_CPP_API_BEGIN
+  //If callbacks are invoked in a nested manner due to caught exceptions
+  //within a callback, we want to only finish the most recent call. All prior
+  //calls should exit as soon as control returns.
+  static int callbacks_depth = 0;
+  int m_callbacks_layer = callbacks_depth++;
 
-    try {
-        for(auto& cb : callbacks(loc)) {
-            if(callbacks_depth != m_callbacks_layer+1) break;
-            cb(*fenix_rt.user_world, fenix_rt.mpi_fail_code);
-        }
-    } catch (const CommException& e) {
-        switch(fenix_rt.callback_exception_mode){
-            case(RETHROW):
-                if(m_callbacks_layer == 0) callbacks_depth = 0;
-                throw;
-            case(SQUASH):
-                break;
-        }
+  try {
+    for (auto& cb : callbacks(loc)) {
+      if (callbacks_depth != m_callbacks_layer + 1) break;
+      cb(*fenix_rt.user_world, fenix_rt.mpi_fail_code);
     }
+  } catch (const CommException& e) {
+    switch (fenix_rt.callback_exception_mode) {
+    case (RETHROW):
+      if (m_callbacks_layer == 0) callbacks_depth = 0;
+      throw;
+    case (SQUASH):
+      break;
+    }
+  }
 
-    //Reset the callback depth when leaving the outermost call
-    if(m_callbacks_layer == 0) callbacks_depth = 0;
+  //Reset the callback depth when leaving the outermost call
+  if (m_callbacks_layer == 0) callbacks_depth = 0;
+  return FENIX_SUCCESS;
+  FENIX_CPP_API_END
 }
 
 } // namespace fenix

--- a/src/fenix_data_group.cpp
+++ b/src/fenix_data_group.cpp
@@ -59,46 +59,77 @@
 #include "mpi.h"
 #include "fenix-config.h"
 #include "fenix_ext.hpp"
+#include "fenix_util.hpp"
 #include "fenix_data_group.hpp"
 #include "fenix_data_member.hpp"
 
 namespace fenix::data {
 
-group_iterator search_group(int id, fenix_data_recovery_t* dr){
+fenix_group_t* search_group(int id){
+  auto dr = fenix_rt.data_recovery;
   for(int i = 0; i < dr->count; i++){
     auto group = dr->group[i];
     if(dr->group[i]->groupid == id){
-      return {i, dr->group[i]};
+      return dr->group[i];
     }
   }
-  return {-1, nullptr};
-}
-group_iterator search_group(int id){
-  return search_group(id, fenix_rt.data_recovery);
+  return nullptr;
 }
 
-group_iterator find_group(int id, fenix_data_recovery_t* dr){
-  auto it = search_group(id, dr);
-  if(it.second == nullptr){
-    debug_print("ERROR: group_id <%d> does not exist\n", id);
-  }
-  return it;
-}
-group_iterator find_group(int id){
-  return find_group(id, fenix_rt.data_recovery);
+fenix_group_t* find_group(int id, std::source_location loc){
+  auto group = search_group(id);
+  if(!group) FENIX_THROW_FROM(FENIX_ERROR_INVALID_GROUPID, loc);
+  return group;
 }
 
-member_iterator fenix_group_t::search_member(int id){
+fenix_group_t::fenix_group_t(
+  int m_groupid, MPI_Comm m_comm, int m_timestart, int m_depth, int m_policy
+) {
+  groupid = m_groupid;
+  comm = m_comm;
+  comm_size = util::comm_size(comm);
+  current_rank = util::comm_rank(comm);
+  timestart = m_timestart;
+  timestamp = -1;
+  depth = m_depth;
+  policy_name = m_policy;
+}
+
+fenix_member_entry_t* fenix_group_t::search_member(int id){
   auto iter = members.find(id);
-  if(iter == members.end()) return {-1, nullptr};
+  if(iter == members.end()) return nullptr;
   assert(iter->first == iter->second.memberid);
-  return {std::distance(members.begin(), iter), &(iter->second)};
+  return &(iter->second);
 }
 
-member_iterator fenix_group_t::find_member(int id){
-  auto it = search_member(id);
-  if(it.first == -1) debug_print("ERROR group <%d>: member_id <%d> does not exist\n", groupid, id);
-  return it;
+fenix_member_entry_t* fenix_group_t::find_member(int id, std::source_location loc) {
+  auto member = search_member(id);
+  if(!member) FENIX_THROW_FROM(FENIX_ERROR_INVALID_MEMBERID, loc);
+  return member;
+}
+
+int fenix_group_t::member_create(
+  int id, void* data, int count, MPI_Datatype datatype
+) {
+  auto [iter, emplaced] = members.try_emplace(id, id, data, count, datatype);
+  if(!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
+  return this->member_create(&iter->second);
+}
+
+int fenix_group_t::member_create(
+  int id, void* data, int count, int datatype_size
+) {
+  auto [iter, emplaced] =
+    members.try_emplace(id, id, data, count, datatype_size);
+  if(!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
+  return this->member_create(&iter->second);
+}
+
+int fenix_group_t::member_delete(int id){
+  auto member = find_member(id);
+  int ret = this->member_delete(member);
+  if(ret == FENIX_SUCCESS) members.erase(id);
+  return ret;
 }
 
 std::vector<int> fenix_group_t::get_member_ids(){
@@ -128,34 +159,6 @@ fenix_data_recovery_t * __fenix_data_recovery_init() {
   return data_recovery;
 }
 
-int member_delete(int groupid, int memberid) {
-  auto [group_index, group] = find_group(groupid);
-  if(!group) return FENIX_ERROR_INVALID_GROUPID;
-
-  auto [member_index, mentry] = group->find_member(memberid);
-  if(!mentry) return FENIX_ERROR_INVALID_MEMBERID;
-
-  if (fenix_rt.options.verbose == 38) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d, member_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index,
-                  member_index);
-  }
-
-  int retval = group->member_delete(memberid);
-
-  if(retval == FENIX_SUCCESS){
-    group->members.erase(memberid);
-  }
-
-  if (fenix_rt.options.verbose == 38) {
-    verbose_print("c-rank: %d, role: %d, m-count: %zu",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role,
-                  group->members.size());
-  }
-
-  return retval;
-}
-
 
 int __fenix_group_delete_direct(fenix_group_t* group){
     //We need this function to remove any allocated pointers
@@ -173,43 +176,24 @@ int __fenix_group_delete_direct(fenix_group_t* group){
     return group->group_delete();
 }
 
-int __fenix_data_recovery_remove_group(int group_index){
-    int retval = !FENIX_SUCCESS;
-    auto data_recovery = fenix_rt.data_recovery;
+int __fenix_data_recovery_remove_group(int groupid){
+    auto dr = fenix_rt.data_recovery;
 
-    if(group_index != -1){
-        for(int index = group_index; index < data_recovery->count-1; index++){
-            data_recovery->group[index] = data_recovery->group[index+1];
-        }
-        data_recovery->count--;
-        retval = FENIX_SUCCESS;
+    bool found = false;
+    for(int i = 0; i < dr->count; i++){
+      if(dr->group[i] && dr->group[i]->groupid == groupid){
+        found = true;
+      }
+      if(found){
+        if(i < dr->count-1) dr->group[i] = dr->group[i+1];
+        else dr->group[i] = nullptr;
+      }
     }
-    return retval;
+    if(!found) FENIX_THROW(FENIX_ERROR_INVALID_GROUPID);
+    dr->count--;
+
+    return FENIX_SUCCESS;
 }
-
-/**
- * @brief
- * @param group_id
- */
-int group_delete(int groupid) {
-  auto [group_index, group] = find_group(groupid);
-  if(!group) return FENIX_ERROR_INVALID_GROUPID;
-
-  if (fenix_rt.options.verbose == 37) {
-    verbose_print("c-rank: %d, group_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), group_index);
-  }
-
-  /* Delete Process */
-  int retval = __fenix_group_delete_direct(group);
-
-  if(retval == FENIX_SUCCESS){
-      retval = __fenix_data_recovery_remove_group(group_index);
-  }
-
-  return retval;
-}
-
 
 void __fenix_data_recovery_destroy( fenix_data_recovery_t *data_recovery )  {
   int group_index;
@@ -223,10 +207,6 @@ void __fenix_data_recovery_destroy( fenix_data_recovery_t *data_recovery )  {
   free( data_recovery );
 }
 
-/**
- * @brief
- * @param
- */
 void __fenix_ensure_data_recovery_capacity(fenix_data_recovery_t* data_recovery) {
   //If we're ensuring there is space for a new group, we need to check that count+1 is < size
   if (data_recovery->count +1 >= data_recovery->total_size) {
@@ -242,10 +222,6 @@ void __fenix_ensure_data_recovery_capacity(fenix_data_recovery_t* data_recovery)
   }
 }
 
-/**
- * @brief
- * @param
- */
 int __fenix_search_groupid(int key, fenix_data_recovery_t *data_recovery) {
   int group_index, found = -1, index = -1;
   for (group_index = 0;
@@ -259,10 +235,6 @@ int __fenix_search_groupid(int key, fenix_data_recovery_t *data_recovery) {
   return index;
 }
 
-/**
- * @brief
- * @param
- */
 int __fenix_find_next_group_position( fenix_data_recovery_t *data_recovery ) {
   //Ensure that we have space.
   __fenix_ensure_data_recovery_capacity(data_recovery);

--- a/src/fenix_data_member.cpp
+++ b/src/fenix_data_member.cpp
@@ -54,6 +54,7 @@
 //@HEADER
 */
 
+#include "fenix_util.hpp"
 #include "fenix_data_group.hpp"
 #include "fenix_data_member.hpp"
 
@@ -68,22 +69,13 @@ fenix_member_entry_t::to_packet(){
   return to_ret;
 }
 
-int __fenix_search_memberid(fenix_group_t* group, int key) {
-  return group->search_member(key).first;
-}
+fenix_member_entry_t::fenix_member_entry_t(
+  int id, void* data, int count, MPI_Datatype datatype
+) : fenix_member_entry_t(id, data, count, __fenix_get_size(datatype)) { };
 
-
-fenix_member_entry_t* __fenix_data_member_add_entry(fenix_group_t* group,
-        int memberid, void* data, int count, int datatype_size){
-    fenix_member_entry_t mentry;
-    mentry.memberid = memberid;
-    mentry.state = OCCUPIED;
-    mentry.user_data = (char*)data;
-    mentry.current_count = count;
-    mentry.datatype_size = datatype_size;
-    group->members[memberid] = mentry;
-
-    return &group->members[memberid];
-}
+fenix_member_entry_t::fenix_member_entry_t(
+  int id, void* data, int count, int dsize
+) : memberid(id), user_data((char*)data), current_count(count),
+    datatype_size(dsize) { };
 
 } //namespace fenix::data

--- a/src/fenix_data_policy.cpp
+++ b/src/fenix_data_policy.cpp
@@ -45,7 +45,7 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Authors Marc Gamell, Eric Valenzuela, Keita Teranishi, Manish Parashar,
-//         and Matthew Whitloc
+//         and Matthew Whitlock
 //
 // Questions? Contact Keita Teranishi (knteran@sandia.gov) and
 //                    Marc Gamell (mgamell@cac.rutgers.edu)
@@ -63,24 +63,17 @@
 
 namespace fenix::data {
 
-int __fenix_policy_get_group(fenix_group_t** group, MPI_Comm comm,
-      int timestart, int depth, int policy_name, void* policy_value, 
-      int* flag){
-   int retval = -1;
-   
-   switch (policy_name){
+fenix_group_t* new_group(
+   int groupid, MPI_Comm comm, int timestart, int depth, int policy_name,
+   void* policy_value, int* flag
+) {
+   switch(policy_name){
       case FENIX_DATA_POLICY_IN_MEMORY_RAID:
-         imr::__fenix_policy_in_memory_raid_get_group(group, comm, timestart, 
-               depth, policy_value, flag);
-         retval = FENIX_SUCCESS;
-         break;
-      default:
-         debug_print("ERROR Fenix_Data_group_create: the specified policy <%d> is not supported.\n", policy_name);
-         retval = -1;
-         break;
+         return new imr::Group(
+            groupid, comm, timestart, depth, (int*)policy_value, flag
+         );
+      default: FENIX_THROW(FENIX_ERROR_INVALID_POLICY_NAME);
    }
-
-   return retval;
 }
 
 }

--- a/src/fenix_data_policy_in_memory_raid.cpp
+++ b/src/fenix_data_policy_in_memory_raid.cpp
@@ -71,6 +71,7 @@
 #include "fenix.h"
 #include "fenix_ext.hpp"
 #include "fenix_opt.hpp"
+#include "fenix_util.hpp"
 #include "fenix_data_subset.hpp"
 #include "fenix_data_policy.hpp"
 #include "fenix_data_group.hpp"
@@ -84,11 +85,6 @@
 #define STORE_PAYLOAD_TAG 2004
 
 namespace fenix::data::imr {
-
-void __fenix_policy_in_memory_raid_get_group(fenix_group_t** group, MPI_Comm comm,
-      int timestart, int depth, void* policy_value, int* flag){
-   *group = new Group(comm, timestart, depth, (int*)policy_value, flag);
-};
 
 Entry::Entry(int size, int max_count)
    : elm_size(size), elm_max_count(max_count) {
@@ -556,9 +552,9 @@ int Member::lrestore(
 }
 
 Group::Group(
-   MPI_Comm m_comm, int timestart, int depth, int* policy, int* flag
-){
-   int* policy_vals = (int*)policy;
+   int m_id, MPI_Comm m_comm, int m_timestart, int m_depth,
+   int* policy_vals, int* flag
+) : fenix_group_t(m_id, m_comm, m_timestart, m_depth, FENIX_DATA_POLICY_IMR) {
    mode = policy_vals ? policy_vals[0] : 1;
    rank_separation = policy_vals ? policy_vals[1] : __fenix_get_world_size(m_comm)/2;
 
@@ -722,13 +718,11 @@ int Group::member_create(fenix_member_entry_t* mentry){
    } else return FENIX_ERROR_MEMBER_EXISTS;
 }
 
-int Group::member_delete(int member_id){
-   auto iter = member_data.find(member_id);
+int Group::member_delete(fenix_member_entry_t* mentry){
+   auto iter = member_data.find(mentry->memberid);
 
    if(iter == member_data.end()){
-      debug_print("ERROR Fenix_Data_member_delete: member_id <%d> does not exist!\n",
-                member_id);
-      return FENIX_ERROR_INVALID_MEMBERID; 
+      FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
    }
 
    member_data.erase(iter);
@@ -877,12 +871,11 @@ int Group::member_restore(
       );
 
       if(!found_members[set_rank]){
-         this->member_create(__fenix_data_member_add_entry(
-            this, packet.memberid, target_buffer, packet.current_count,
+         fenix_group_t::member_create(
+            packet.memberid, target_buffer, packet.current_count,
             packet.datatype_size
-         ));
+         );
          member = find_member(member_id);
-         assert(member);
       }
    }
 

--- a/src/fenix_data_recovery.cpp
+++ b/src/fenix_data_recovery.cpp
@@ -54,8 +54,6 @@
 //@HEADER
 */
 
-
-
 #include "fenix.hpp"
 #include "fenix_data_policy.hpp"
 #include "fenix_opt.hpp"
@@ -71,548 +69,311 @@ using namespace fenix::data;
 
 namespace fenix::data {
 
-int group_create( int groupid, MPI_Comm comm, int timestart, int depth, int policy_name,
-        void* policy_value, int* flag) {
+int group_create(
+  int groupid, MPI_Comm comm, int timestart, int depth, int policy_name,
+  void* policy_value, int* flag
+) {
+  FENIX_CPP_API_BEGIN
+  if (timestart < 0) FENIX_THROW(FENIX_ERROR_INVALID_TIMESTART);
+  if (depth < -1) FENIX_THROW(FENIX_ERROR_INVALID_DEPTH);
 
-  int retval = -1;
+  auto group = search_group(groupid);
+  fenix_data_recovery_t* dr = fenix_rt.data_recovery;
 
-  /* Retrieve the array index of the group maintained under the cover. */
-  int group_index = __fenix_search_groupid( groupid, fenix_rt.data_recovery );
+  if (!group) {
+    // Initialize Group
+    group = new_group(
+      groupid, comm, timestart, depth, policy_name, policy_value, flag
+    );
 
-  if (fenix_rt.options.verbose == 12) {
-
-    verbose_print("c-rank: %d, group_index: %d\n",   __fenix_get_current_rank(fenix_rt.new_world), group_index);
-  }
-
-
-  /* Check the integrity of user's input */
-  if ( timestart < 0 ) {
-
-    debug_print("ERROR Fenix_Data_group_create: time_stamp <%d> must be greater than or equal to zero\n", timestart);
-    retval = FENIX_ERROR_INVALID_TIMESTAMP;
-
-  } else if ( depth < -1 ) {
-
-    debug_print("ERROR Fenix_Data_group_create: depth <%d> must be greater than or equal to -1\n",depth);
-    retval = FENIX_ERROR_INVALID_DEPTH;
-
+    // Place in an available group slot
+    dr->group[__fenix_find_next_group_position(dr)] = group;
+    // Update the count AFTER finding next group position.
+    dr->count++;
   } else {
+    // Already created. Renew the MPI communicator
+    group->comm = comm;
+    MPI_Comm_rank(comm, &(group->current_rank));
 
-    /* This code block checks the need for data recovery.   */
-    /* If so, recover the data and set the recovery         */
-    /* for member recovery.                                 */
-
-    int i;
-    int remote_need_recovery;
-    fenix_group_t *group;
-    MPI_Status status;
-
-    fenix_data_recovery_t *data_recovery = fenix_rt.data_recovery;
-
-    /* Initialize Group.  The group hasn't been created.       */
-    /* I am either a brand-new process or a recovered process. */
-    if (group_index == -1 ) {
-
-      if (fenix_rt.options.verbose == 12 &&   __fenix_get_current_rank(comm) == 0) {
-         printf("this is a new group!\n");
-      }
-
-      /* Obtain an available group slot */
-      group_index = __fenix_find_next_group_position(data_recovery);
-
-      /* Initialize Group */
-      __fenix_policy_get_group(data_recovery->group + group_index, comm, timestart,
-              depth, policy_name, policy_value, flag);
-
-      //The group has filled any group-specific details, we need to fill in the core details.
-      group = (data_recovery->group[ group_index ] );
-      group->groupid = groupid;
-      group->timestart = timestart;
-      group->timestamp = -1; //indicates no commits yet
-      group->depth = depth;
-      group->comm = comm;
-      group->policy_name = policy_name;
-      MPI_Comm_rank(comm, &(group->current_rank));
-
-
-      //Update the count AFTER finding next group position.
-      data_recovery->count++;
-
-      if ( fenix_rt.options.verbose == 12) {
-        verbose_print(
-                "c-rank: %d, g-groupid: %d, g-timestart: %d, g-depth: %d\n",
-                __fenix_get_current_rank(fenix_rt.new_world), group->groupid,
-                group->timestart,
-                group->depth);
-      }
-
-    } else { /* Already created. Renew the MPI communicator  */
-
-      group = ( data_recovery->group[group_index] );
-      group->comm = comm; /* Renew communicator */
-      MPI_Comm_rank(comm, &(group->current_rank));
-
-
-      //Reinit group metadata as needed w/ new communicator.
-      group->reinit(flag);
-    }
-
-
-    /* Global agreement among the group */
-    retval = FENIX_SUCCESS;
+    // Reinit group metadata as needed w/ new communicator.
+    group->reinit(flag);
   }
-  return retval;
+
+  return FENIX_SUCCESS;
+  FENIX_CPP_API_END
 }
 
-bool group_created(int groupid){
-  return search_group(groupid).second != nullptr;
+bool group_created(int groupid) {
+  FENIX_CPP_API_BEGIN
+  return search_group(groupid) != nullptr;
+  FENIX_CPP_API_END
 }
 
 int member_create(
-  int groupid, int memberid, void *data, int count, MPI_Datatype datatype
+  int groupid, int memberid, void* data, int count, MPI_Datatype datatype
 ) {
-  auto [group_index, group] = find_group(groupid);
-  if(!group) return FENIX_ERROR_INVALID_GROUPID;
-
-  auto [member_index, mentry] = group->search_member(memberid);
-  if(mentry){
-    debug_print("ERROR Fenix_Data_member_create: member_id <%d> already exists\n",
-                memberid);
-    return FENIX_ERROR_INVALID_MEMBERID;
-  }
-
-  if (fenix_rt.options.verbose == 13) {
-    verbose_print("c-rank: %d, group_index: %d, member_index: %d\n",
-                   __fenix_get_current_rank(fenix_rt.new_world),
-                  group_index, member_index);
-  }
-
-  //First, we'll make a fenix-core member entry, then pass that info to
-  //the specific data policy.
-  mentry = __fenix_data_member_add_entry(group, memberid, data, count, __fenix_get_size(datatype));
-
-  //Pass the info along to the policy
-  return group->member_create(mentry);
+  FENIX_CPP_API_BEGIN
+  return find_group(groupid)->member_create(memberid, data, count, datatype);
+  FENIX_CPP_API_END
 }
 
-bool member_created(int group_id, int member_id){
-  auto [group_idx, group] = search_group(group_id);
-  return group && group->search_member(member_id).second;
+bool member_created(int group_id, int member_id) {
+  FENIX_CPP_API_BEGIN
+  auto group = search_group(group_id);
+  return group && group->search_member(member_id);
+  FENIX_CPP_API_END
 }
 
 int member_store(int groupid, int memberid, const DataSubset& specifier) {
-  auto [group_index, group] = find_group(groupid);
-  if(!group){
-    debug_print("ERROR Fenix_Data_member_store: group_id <%d> does not exist", groupid);
-    return FENIX_ERROR_INVALID_GROUPID;
-  }
-
-  return group->member_store(memberid, specifier);
+  FENIX_CPP_API_BEGIN
+  return find_group(groupid)->member_store(memberid, specifier);
+  FENIX_CPP_API_END
 }
 
 int member_storev(int groupid, int memberid, const DataSubset& specifier) {
-  auto [group_index, group] = find_group(groupid);
-  if(!group){
-    debug_print("ERROR Fenix_Data_member_storev: group_id <%d> does not exist", groupid);
-    return FENIX_ERROR_INVALID_GROUPID;
-  }
-
-  return group->member_storev(memberid, specifier);
+  FENIX_CPP_API_BEGIN
+  return find_group(groupid)->member_storev(memberid, specifier);
+  FENIX_CPP_API_END
 }
 
-int member_istore(int groupid, int memberid, const DataSubset& specifier,
-                  Fenix_Request *request) {
+int member_istore(
+  int groupid, int memberid, const DataSubset& specifier, Fenix_Request* request
+) {
+  FENIX_CPP_API_BEGIN
   fatal_print("unimplemented");
-  auto [group_index, group] = find_group(groupid);
-  if(!group){
-    debug_print("ERROR Fenix_Data_member_istore: group_id <%d> does not exist", groupid);
-    return FENIX_ERROR_INVALID_GROUPID;
-  }
-
-  return group->member_istore(memberid, specifier, request);
+  return find_group(groupid)->member_istore(memberid, specifier, request);
+  FENIX_CPP_API_END
 }
 
 int member_istorev(
-  int groupid, int memberid, const DataSubset& specifier, Fenix_Request *request
+  int groupid, int memberid, const DataSubset& specifier, Fenix_Request* request
 ) {
+  FENIX_CPP_API_BEGIN
   fatal_print("unimplemented");
-  auto [group_index, group] = find_group(groupid);
-  if(!group){
-    debug_print("ERROR Fenix_Data_member_istorev: group_id <%d> does not exist", groupid);
-    return FENIX_ERROR_INVALID_GROUPID;
-  }
-
-  return group->member_istore(memberid, specifier, request);
+  return find_group(groupid)->member_istore(memberid, specifier, request);
+  FENIX_CPP_API_END
 }
 
-int commit(int groupid, int *timestamp) {
-  /* No communication is performed */
-  /* Return the new timestamp      */
-  int retval = -1;
-  int group_index = __fenix_search_groupid(groupid, fenix_rt.data_recovery );
-  if (fenix_rt.options.verbose == 22) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d\n",   __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index);
-  }
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_commit: group_id <%d> does not exist\n", groupid);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-
-    if (group->timestamp != -1) group->timestamp++;
-    else group->timestamp = group->timestart;
-
-    group->commit();
-
-    if (timestamp != NULL) {
-      *timestamp = group->timestamp;
-    }
-
-    retval = FENIX_SUCCESS;
-  }
-  return retval;
+int commit(int groupid, int* timestamp) {
+  FENIX_CPP_API_BEGIN
+  auto g = find_group(groupid);
+  g->timestamp = g->timestamp == -1 ? g->timestart : g->timestamp + 1;
+  if (timestamp) *timestamp = g->timestamp;
+  return g->commit();
+  FENIX_CPP_API_END
 }
 
-int commit_barrier(int groupid, int *timestamp) {
-  int retval = -1;
-  int group_index = __fenix_search_groupid(groupid, fenix_rt.data_recovery );
-  if (fenix_rt.options.verbose == 23) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index);
+int commit_barrier(int groupid, int* timestamp) {
+  FENIX_CPP_API_BEGIN
+  //We want to make sure there aren't any failed MPI operations (IE unfinished
+  //stores) But we don't want to fail to commit if a failure has happened after
+  //all stores.
+  auto g = find_group(groupid);
+
+  //Our error handler also enters an agree, with a unique location bit set.
+  //So if we aren't all here, we've hit an error already.
+  int location = FENIX_DATA_COMMIT_BARRIER_LOC;
+  int err = MPIX_Comm_agree(*fenix_rt.user_world, &location);
+  bool can_commit = location == FENIX_DATA_COMMIT_BARRIER_LOC;
+  bool must_recover = !can_commit || err != MPI_SUCCESS;
+
+  int ret = FENIX_ERROR_COMMIT_BARRIER;
+  if (can_commit) {
+    g->timestamp = g->timestamp == -1 ? g->timestart : g->timestamp + 1;
+    if (timestamp) *timestamp = g->timestamp;
+    ret = g->commit();
   }
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_commit: group_id <%d> does not exist\n", groupid);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-
-    //We want to make sure there aren't any failed MPI operations (IE unfinished stores)
-    //But we don't want to fail to commit if a failure has happened since a successful store.
-    int old_failure_handling = fenix_rt.ignore_errs;
-    fenix_rt.ignore_errs = 1;
-
-    int can_commit = 0;
-
-    //We'll use comm_agree as a resilient barrier
-    //Our error handler also enters an agree, with a unique location bit set.
-    //So if we aren't all here, we've hit an error already.
-
-    int location = FENIX_DATA_COMMIT_BARRIER_LOC;
-    int ret = MPIX_Comm_agree(*fenix_rt.user_world, &location);
-    if(location == FENIX_DATA_COMMIT_BARRIER_LOC) can_commit = 1;
-
-    fenix_rt.ignore_errs = old_failure_handling;
-
-    if(can_commit == 1){
-        if (group->timestamp != -1) group->timestamp++;
-        else group->timestamp = group->timestart;
-        retval = group->commit();
-    }
-
-
-    if(can_commit != 1 || ret != MPI_SUCCESS) {
-        //A rank failure has happened, lets trigger error handling if enabled.
-        int throwaway = 1;
-        MPI_Allreduce(MPI_IN_PLACE, &throwaway, 1, MPI_INT, MPI_SUM, *fenix_rt.user_world);
-    }
-
-
-    if (timestamp != NULL) {
-      *timestamp = group->timestamp;
-    }
+  if (must_recover) {
+    MPI_Comm_call_errhandler(*fenix_rt.user_world, MPI_ERR_PROC_FAILED);
   }
-  return retval;
+  return ret;
+  FENIX_CPP_API_END
 }
 
-int member_restore(int groupid, int memberid, void *data, int maxcount, int timestamp, DataSubset& data_found) {
-  int retval =  FENIX_SUCCESS;
+int member_restore(
+  int groupid, int memberid, void* data, int maxcount, int timestamp,
+  DataSubset& data_found
+) {
+  FENIX_CPP_API_BEGIN
   data_found = {};
-
-  int group_index = __fenix_search_groupid(groupid, fenix_rt.data_recovery);
-
-  if (fenix_rt.options.verbose == 25) {
-    int member_index = -1;
-    if(group_index != -1) member_index = __fenix_search_memberid(fenix_rt.data_recovery->group[group_index], memberid);
-    verbose_print("c-rank: %d, role: %d, group_index: %d, member_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index,
-                  member_index);
-  }
-
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_member_restore: group_id <%d> does not exist\n",
-                groupid);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-    retval = group->member_restore(memberid, data, maxcount, timestamp, data_found);
-  }
-  return retval;
+  return find_group(groupid)->member_restore(
+    memberid, data, maxcount, timestamp, data_found
+  );
+  FENIX_CPP_API_END
 }
 
-int member_lrestore(int groupid, int memberid, void *data, int maxcount, int timestamp, DataSubset& data_found) {
-  int retval =  FENIX_SUCCESS;
+int member_lrestore(
+  int groupid, int memberid, void* data, int maxcount, int timestamp,
+  DataSubset& data_found
+) {
+  FENIX_CPP_API_BEGIN
   data_found = {};
-
-  int group_index = __fenix_search_groupid(groupid, fenix_rt.data_recovery);
-  int member_index = -1;
-
-  if(group_index != -1) member_index = __fenix_search_memberid(fenix_rt.data_recovery->group[group_index], memberid);
-
-  if (fenix_rt.options.verbose == 25) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d, member_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index,
-                  member_index);
-  }
-
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_member_lrestore: group_id <%d> does not exist\n",
-                groupid);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-    retval = group->member_lrestore(memberid, data, maxcount, timestamp, data_found);
-  }
-  return retval;
+  return find_group(groupid)->member_lrestore(
+    memberid, data, maxcount, timestamp, data_found
+  );
+  FENIX_CPP_API_END
 }
 
-std::optional<std::vector<int>> group_members(int group_id){
-  auto [group_index, group] = find_group(group_id);
-  if(!group) return {};
-  return group->get_member_ids();
+std::optional<std::vector<int>> group_members(int group_id) {
+  assert(initialized());
+  auto group = search_group(group_id);
+  if (group) return group->get_member_ids();
+  return {};
 }
 
-std::optional<std::vector<int>> group_snapshots(int group_id){
-  auto [group_index, group] = find_group(group_id);
-  if(!group) return {};
-  return group->get_snapshots();
+std::optional<std::vector<int>> group_snapshots(int group_id) {
+  assert(initialized());
+  auto group = search_group(group_id);
+  if (group) return group->get_snapshots();
+  return {};
 }
 
 int snapshot_delete(int group_id, int time_stamp) {
-  int retval = -1;
-  int group_index = __fenix_search_groupid(group_id, fenix_rt.data_recovery );
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_snapshot_delete: group_id <%d> does not exist\n",
-                group_id);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else if (time_stamp < 0) {
-    debug_print(
-            "ERROR Fenix_Data_snapshot_delete: time_stamp <%d> must be greater than zero\n",
-            time_stamp);
-    retval = FENIX_ERROR_INVALID_TIMESTAMP;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-    retval = group->snapshot_delete(time_stamp);
+  FENIX_CPP_API_BEGIN
+  if (time_stamp < 0) FENIX_THROW(FENIX_ERROR_INVALID_TIMESTAMP);
+  return find_group(group_id)->snapshot_delete(time_stamp);
+  FENIX_CPP_API_END
+}
+
+int member_delete(int groupid, int memberid) {
+  FENIX_CPP_API_BEGIN
+  return find_group(groupid)->member_delete(memberid);
+  FENIX_CPP_API_END
+}
+
+int group_delete(int groupid) {
+  FENIX_CPP_API_BEGIN
+  int ret = find_group(groupid)->group_delete();
+  if (ret == FENIX_SUCCESS) {
+    ret = __fenix_data_recovery_remove_group(groupid);
   }
-  return retval;
+  return ret;
+  FENIX_CPP_API_END
 }
 
 } // namespace fenix::data
 
-int Fenix_Data_member_attr_set(int groupid, int memberid, int attributename,
-                         void *attributevalue, int *flag) {
-  auto [group_index, group] = find_group(groupid);
-  if(!group) return FENIX_ERROR_INVALID_GROUPID;
+using namespace fenix;
 
-  auto [member_index, mentry] = group->find_member(memberid);
-  if(!mentry) return FENIX_ERROR_INVALID_MEMBERID;
+int Fenix_Data_member_attr_set(
+  int groupid, int memberid, int attributename, void* attributevalue, int* flag
+) {
+  FENIX_C_API_BEGIN
+  auto group = find_group(groupid);
+  auto mentry = group->find_member(memberid);
 
-  if (fenix_rt.options.verbose == 35) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d, member_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index,
-                  member_index);
-  }
-
-  int my_datatype_size;
-  int myerr;
-
-  //Always pass attribute changes along to group - they might have unknown attributes
-  //or side-effects to handle from changes. They get change info before
-  //changes are made, in case they need prior state.
-  int retval = group->member_set_attribute(mentry, attributename,
-          attributevalue, flag);
+  //Always pass attribute changes along to group - they might have unknown
+  //attributes or side-effects to handle from changes. They get change info
+  //before changes are made, in case they need prior state.
+  int retval =
+    group->member_set_attribute(mentry, attributename, attributevalue, flag);
+  if (retval != FENIX_SUCCESS) return retval;
 
   switch (attributename) {
-    case FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER:
-      mentry->user_data = (char*)attributevalue;
-      break;
-    case FENIX_DATA_MEMBER_ATTRIBUTE_COUNT:
-      mentry->current_count = *((int *) (attributevalue));
-      retval = FENIX_SUCCESS;
-      break;
-    case FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE:
+  case FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER:
+    mentry->user_data = (char*)attributevalue;
+    break;
+  case FENIX_DATA_MEMBER_ATTRIBUTE_COUNT:
+    mentry->current_count = *((int*)(attributevalue));
+    break;
+  case FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE: {
+    MPI_Datatype* dtype = (MPI_Datatype*)attributevalue;
+    int dtype_size;
+    int err = MPI_Type_size(*dtype, &dtype_size);
+    if (err) throw RuntimeException("Invalid MPI_Datatype");
 
-      myerr = MPI_Type_size(*((MPI_Datatype *)(attributevalue)), &my_datatype_size);
-
-      if( myerr ) {
-        debug_print(
-                "ERROR Fenix_Data_member_attr_get: Fenix currently does not support this MPI_DATATYPE; invalid attribute_value <%d>\n",
-                attributevalue);
-        retval = FENIX_ERROR_INVALID_ATTRIBUTE_NAME;
-      }
-
-      mentry->datatype_size = my_datatype_size;
-      retval = FENIX_SUCCESS;
-      break;
-
-    default:
-      //Only an issue if the policy also doesn't have this attribute.
-      if(retval){
-        debug_print("ERROR Fenix_Data_member_attr_get: invalid attribute_name <%d>\n",
-                    attributename);
-        retval = FENIX_ERROR_INVALID_ATTRIBUTE_NAME;
-      }
-      break;
+    mentry->datatype_size = dtype_size;
+    break;
+  }
+  default:
+    // No problem, since the group policy successfully handled this
+    break;
   }
 
-  return retval;
-}
-
-int Fenix_Data_group_get_number_of_snapshots(int group_id, int *num_snapshots) {
-  int retval = -1;
-  int group_index = __fenix_search_groupid(group_id, fenix_rt.data_recovery );
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_commit: group_id <%d> does not exist\n", group_id);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-    retval = group->get_number_of_snapshots(num_snapshots);
-  }
-  return retval;
-}
-
-int Fenix_Data_group_get_snapshot_at_position(int groupid, int position, int *timestamp) {
-  int retval = -1;
-  int group_index = __fenix_search_groupid(groupid, fenix_rt.data_recovery );
-  if (fenix_rt.options.verbose == 33) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index);
-  }
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_commit: group_id <%d> does not exist\n", groupid);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-    *timestamp = group->timestamp - position;
-  }
-  return retval;
-}
-
-int Fenix_Data_member_attr_get(int groupid, int memberid, int attributename,
-                         void *attributevalue, int *flag, int sourcerank) {
-  auto [group_index, group] = find_group(groupid);
-  if(!group) return FENIX_ERROR_INVALID_GROUPID;
-
-  auto [member_index, mentry] = group->find_member(memberid);
-  if(!mentry) return FENIX_ERROR_INVALID_MEMBERID;
-
-  if (fenix_rt.options.verbose == 34) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d, member_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index,
-                  member_index);
-  }
-
-  return group->member_get_attribute(mentry, attributename,
-          attributevalue, flag, sourcerank);
-}
-
-int Fenix_Data_group_get_redundancy_policy(int groupid, int* policy_name, int* policy_value, int* flag){
-  int retval = -1;
-  int group_index = __fenix_search_groupid( groupid, fenix_rt.data_recovery );
-
-  if(group_index == -1){
-    debug_print("ERROR Fenix_Data_member_create: group_id <%d> does not exist\n",
-                groupid);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t* group = fenix_rt.data_recovery->group[group_index];
-    retval = group->get_redundant_policy(policy_name, policy_value, flag);
-  }
-
-  return retval;
-}
-
-int Fenix_Data_member_restore_from_rank(int groupid, int memberid, void *target_buffer,
-                             int max_count, int time_stamp, int source_rank) {
-  int retval =  FENIX_SUCCESS;
-  int group_index = __fenix_search_groupid(groupid, fenix_rt.data_recovery);
-  int member_index = -1;
-
-  if(group_index != -1) member_index = __fenix_search_memberid(fenix_rt.data_recovery->group[group_index], memberid);
-
-  if (fenix_rt.options.verbose == 25) {
-    verbose_print("c-rank: %d, role: %d, group_index: %d, member_index: %d\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, group_index,
-                  member_index);
-  }
-
-  if (group_index == -1) {
-    debug_print("ERROR Fenix_Data_member_restore: group_id <%d> does not exist\n",
-                groupid);
-    retval = FENIX_ERROR_INVALID_GROUPID;
-  } else {
-    fenix_group_t *group = (fenix_rt.data_recovery->group[group_index]);
-    retval = group->member_restore_from_rank(memberid, target_buffer,
-            max_count, time_stamp, source_rank);
-  }
-  return retval;
-}
-
-int Fenix_Data_group_get_number_of_members(int group_id, int *num_members) {
-  auto group = find_group(group_id).second;
-  if(!group) return FENIX_ERROR_INVALID_GROUPID;
-
-  *num_members = group->members.size();
   return FENIX_SUCCESS;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_group_get_member_at_position(int group_id, int *member_id, int position) {
-  auto [group_index, group] = find_group(group_id);
-  if(!group) return FENIX_ERROR_INVALID_GROUPID;
+int Fenix_Data_group_get_number_of_snapshots(int group_id, int* num_snapshots) {
+  FENIX_C_API_BEGIN
+  return find_group(group_id)->get_number_of_snapshots(num_snapshots);
+  FENIX_C_API_END
+}
 
-  if(position < 0 || position >= group->members.size()){
-    debug_print(
-            "ERROR Fenix_Data_group_get_member_at_position: position <%d> must be a value between 0 and number_of_members-1 \n",
-            position);
-    return FENIX_ERROR_INVALID_POSITION;
+int Fenix_Data_group_get_snapshot_at_position(
+  int groupid, int position, int* timestamp
+) {
+  FENIX_C_API_BEGIN
+  return find_group(groupid)->get_snapshot_at_position(position, timestamp);
+  FENIX_C_API_END
+}
+
+int Fenix_Data_member_attr_get(
+  int groupid, int memberid, int attributename, void* attributevalue, int* flag,
+  int sourcerank
+) {
+  FENIX_C_API_BEGIN
+  auto g = find_group(groupid);
+  return g->member_get_attribute(
+    g->find_member(memberid), attributename, attributevalue, flag, sourcerank
+  );
+  FENIX_C_API_END
+}
+
+int Fenix_Data_group_get_redundancy_policy(
+  int groupid, int* policy_name, int* policy_value, int* flag
+) {
+  FENIX_C_API_BEGIN
+  return find_group(groupid)->get_redundant_policy(
+    policy_name, policy_value, flag
+  );
+  FENIX_C_API_END
+}
+
+int Fenix_Data_member_restore_from_rank(
+  int groupid, int memberid, void* target_buffer, int max_count, int time_stamp,
+  int source_rank
+) {
+  FENIX_C_API_BEGIN
+  fatal_print("unimplemented");
+  return find_group(groupid)->member_restore_from_rank(
+    memberid, target_buffer, max_count, time_stamp, source_rank
+  );
+  FENIX_C_API_END
+}
+
+int Fenix_Data_group_get_number_of_members(int group_id, int* num_members) {
+  FENIX_C_API_BEGIN
+  *num_members = find_group(group_id)->members.size();
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
+}
+
+int Fenix_Data_group_get_member_at_position(
+  int group_id, int* member_id, int position
+) {
+  FENIX_C_API_BEGIN
+  auto group = find_group(group_id);
+  if (position < 0 || position >= group->members.size()) {
+    FENIX_THROW(FENIX_ERROR_INVALID_POSITION);
   }
   auto iter = group->members.begin();
   std::advance(iter, position);
   *member_id = iter->first;
   return FENIX_SUCCESS;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_wait( Fenix_Request request ) {
-  int retval = -1;
-  int result = __fenix_mpi_wait(&(request.mpi_recv_req));
-
-  if (result != MPI_SUCCESS) {
-    retval = FENIX_SUCCESS;
-  } else {
-    retval = FENIX_ERROR_DATA_WAIT;
-  }
-
-  result = __fenix_mpi_wait(&(request.mpi_send_req));
-
-  if (result != MPI_SUCCESS) {
-    retval = FENIX_SUCCESS;
-  } else {
-    retval = FENIX_ERROR_DATA_WAIT;
-  }
-
-  return retval;
+int Fenix_Data_wait(Fenix_Request request) {
+  FENIX_C_API_BEGIN
+  fatal_print("unimplemented");
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
 }
 
-int Fenix_Data_test(Fenix_Request request, int *flag) {
-  int retval = -1;
-  int result = ( __fenix_mpi_test(&(request.mpi_recv_req)) & __fenix_mpi_test(&(request.mpi_send_req))) ;
-
-  if ( result == 1 ) {
-    *flag = 1;
-    retval = FENIX_SUCCESS;
-  } else {
-    *flag = 0 ; // incomplete error?
-    retval = FENIX_ERROR_DATA_WAIT;
-  }
-  return retval;
+int Fenix_Data_test(Fenix_Request request, int* flag) {
+  FENIX_C_API_BEGIN
+  fatal_print("unimplemented");
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
 }
-

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -615,7 +615,8 @@ int __fenix_spare_rank(){
     return __fenix_spare_rank_within(*fenix_rt.world);
 }
 
-int detect_failures(bool do_recovery){
+int detect_failures(bool do_recovery) {
+    FENIX_CPP_API_BEGIN
     if(!fenix_rt.new_world_exists) return FENIX_ERROR_UNINITIALIZED;
 
     int old_ignore_errs = fenix_rt.ignore_errs;
@@ -628,6 +629,7 @@ int detect_failures(bool do_recovery){
     
     fenix_rt.ignore_errs = old_ignore_errs;
     return ret;
+    FENIX_CPP_API_END
 }
 
 void __fenix_finalize_spare()
@@ -799,8 +801,8 @@ void __fenix_postinit()
     }
 }
 
-int Fenix_Finalize()
-{
+int Fenix_Finalize() {
+    FENIX_C_API_BEGIN
     int location = FENIX_FINALIZE_LOC;
     MPIX_Comm_agree(*fenix_rt.user_world, &location);
     if(location != FENIX_FINALIZE_LOC){
@@ -867,4 +869,5 @@ int Fenix_Finalize()
     /* Free up any C++ data structures, reset default variables */
     fenix_rt = {};
     return FENIX_SUCCESS;
+    FENIX_C_API_END
 }


### PR DESCRIPTION
PR for after cleanup merges. Main differences are the RuntimeException class and the FENIX_(C|CPP)\_API_(BEGIN|END) macros. 

RuntimeException supports std::source_location to give more detailed error information from an exception thrown with just the fenix error code, so we don't need per-function printouts to get the function name.

The API macros use function-try-blocks to wrap the entire functions in try-catches. Then, they use the ScopedSetting helpers to set up consistent error handling settings within the Fenix runtime. I.E. no more "in case errors are ignored," "in case jumping is enabled," etc - we can rely on exception handling within the runtime. The catch blocks handle making sure we are complying with whatever error handling scheme the user has requested at that point.

Note that the default behavior for C and CPP is for RuntimeExceptions to be thrown. This means C code will simply have to exit if runtime exceptions are detected, but that seems like a more sane default to me. Most of the runtime exceptions are actual user-code bugs, not correct-but-occasionally-exceptional usage, so the behavior of programs had to be checking return codes and aborting anyway. However, compiler definitions FENIX_(C|CPP)_CATCH_RUNTIME_EXCEPTIONS can enable the old behavior by catching runtime exceptions, debug_printing their info (if debug printing is enabled), and returning their error code from the function. TODO: add CMake options to enable those compiler definitions.