### PR TITLE
(API Breaking) New options API, remove setting configurations from Fenix_Init

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,9 @@ AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 # );
 AlignAfterOpenBracket: BlockIndent
 
+# Align assignments not separated by non-assignment or empty line
+AlignConsecutiveAssignments: AcrossComments
+
 # Function calls and init lists try to fit args on same line
 PackConstructorInitializers: BinPack
 BinPackArguments: true

--- a/examples/01_hello_world/fenix/fenix_hello_world.c
+++ b/examples/01_hello_world/fenix/fenix_hello_world.c
@@ -89,8 +89,7 @@ int main(int argc, char** argv) {
   MPI_Comm new_comm;
   int error;
   Fenix_Init(
-    &fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, 0,
-    MPI_INFO_NULL, &error
+    &fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, &error
   );
 
   if (fenix_status != FENIX_ROLE_INITIAL_RANK) {

--- a/examples/02_send_recv/fenix/fenix_ring.c
+++ b/examples/02_send_recv/fenix/fenix_ring.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
   }
   MPI_Comm_dup(MPI_COMM_WORLD, &world_comm);
   Fenix_Init(&fenix_role, world_comm, &new_comm, &argc, &argv,
-             spare_ranks, 0, info, &error);
+             spare_ranks, &error);
 
   if(error){
     fprintf(stderr, "FAILURE, Fenix_Init error %d\n", error);

--- a/examples/03_reduce/fenix/fenix_reduce.c
+++ b/examples/03_reduce/fenix/fenix_reduce.c
@@ -82,7 +82,6 @@ int main(int argc, char** argv) {
   int fenix_role;
   MPI_Comm world_comm = NULL;
   MPI_Comm new_comm = NULL;
-  int spawn_mode = 0;
   int error;
   float local_sum = 0;
   int i;
@@ -105,8 +104,7 @@ int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
   MPI_Comm_dup(MPI_COMM_WORLD, &world_comm);
   Fenix_Init(
-    &fenix_role, world_comm, &new_comm, &argc, &argv, spare_ranks, spawn_mode,
-    MPI_INFO_NULL, &error
+    &fenix_role, world_comm, &new_comm, &argc, &argv, spare_ranks, &error
   );
 
   MPI_Comm_rank(new_comm, &world_rank);

--- a/examples/04_Isend_Irecv/fenix/fenix_stencil_1D.c
+++ b/examples/04_Isend_Irecv/fenix/fenix_stencil_1D.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
   MPI_Comm_dup(MPI_COMM_WORLD, &world_comm);
   MPI_Comm_rank(world_comm, &rank);
 
-  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, 0, MPI_INFO_NULL,
+  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks,
              &error);
 
   if (fenix_status == FENIX_ROLE_INITIAL_RANK) {

--- a/examples/05_subset_create/subset_create.c
+++ b/examples/05_subset_create/subset_create.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
   MPI_Init(&argc, &argv);
   MPI_Comm_dup(MPI_COMM_WORLD, &world_comm);
   Fenix_Init(&fenix_role, world_comm, &new_comm, &argc, &argv,
-             spare_ranks, 0, info, &error);
+             spare_ranks, &error);
 
   MPI_Comm_size(new_comm, &num_ranks);
   MPI_Comm_rank(new_comm, &rank);

--- a/examples/06_subset_createv/subset_createv.c
+++ b/examples/06_subset_createv/subset_createv.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
   MPI_Init(&argc, &argv);
   MPI_Comm_dup(MPI_COMM_WORLD, &world_comm);
   Fenix_Init(&fenix_role, world_comm, &new_comm, &argc, &argv,
-             spare_ranks, 0, info, &error);
+             spare_ranks, &error);
 
   MPI_Comm_size(new_comm, &num_ranks);
   MPI_Comm_rank(new_comm, &rank);

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -351,7 +351,7 @@ int Fenix_Initialized(int *flag);
  * @param[in] option  The option to configure setting to.
  * @returnstatus
  */
-int Fenix_set_option(Fenix_Setting_name setting, int option);
+int Fenix_set_option(Fenix_Setting_name setting, unsigned option);
 
 /**
  * @brief Get the current option for a Fenix setting.
@@ -362,7 +362,7 @@ int Fenix_set_option(Fenix_Setting_name setting, int option);
  * @param[out] option  The current option of the setting.
  * @returnstatus
  */
-int Fenix_get_option(Fenix_Setting_name setting, int option);
+int Fenix_get_option(Fenix_Setting_name setting, unsigned* option);
 
 /**
  * @brief Register a callback to be invoked after failure process recovery.

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -119,6 +119,8 @@ typedef enum {
     FENIX_ERROR_NODATA_FOUND,
     FENIX_ERROR_INTERN,
     FENIX_ERROR_CANCELLED,
+    FENIX_ERROR_INVALID_SETTING_NAME,
+    FENIX_ERROR_INVALID_SETTING_OPTION,
     //Warnings are positive
     FENIX_WARNING_SPARE_RANKS_DEPLETED = 100,
     FENIX_WARNING_PARTIAL_RESTORE,
@@ -161,15 +163,68 @@ typedef enum {
 } Fenix_Rank_role;
 
 /**
+ * @brief Global Fenix settings.
+ */
+typedef enum {
+    //!See #Fenix_Recovery_mode
+    FENIX_RECOVERY_MODE,
+    //!See #Fenix_Resume_mode
+    FENIX_RESUME_MODE,
+    //!See #Fenix_Unhandled_mode
+    FENIX_UNHANDLED_MODE,
+    //!See #Fenix_Callback_exception_mode
+    FENIX_CALLBACK_EXCEPTION_MODE,
+
+    //!Not a valid option.
+    FENIX_SETTING_NAME_MAXCODE
+} Fenix_Setting_name;
+
+/**
+ * @brief Options for recovering after a failed rank is detected
+ */
+typedef enum {
+    //!Do not repair communicator, immediately resume per #FENIX_RESUME_MODE
+    FENIX_RECOVERY_IGNORE,
+    /**
+     * @brief Do not repair communicator, otherwise behave normally
+     *
+     * This includes calling the PRE_RECOVERY and POST_RECOVERY callbacks
+     */
+    FENIX_RECOVERY_NOOP,
+    //!Repair the communicator with spares or by shrinking
+    FENIX_RECOVERY_REPAIR,
+    //!@unimplemented As REPAIR, but attempt to respawn failed processes
+    FENIX_RECOVERY_SPAWN,
+
+    //!Not a valid option
+    FENIX_RECOVERY_MODE_MAXCODE
+} Fenix_Recovery_mode;
+
+/**
  * @brief Options for passing control back to application after recovery.
  */
 typedef enum {
-    //!Return to Fenix_Init via longjmp (default)
+    /**
+     * @brief Return to Fenix_Init via longjmp (default)
+     *
+     * The value of variables set before the longjmp are subject to undefined
+     * behavior from compiler optimizations. To ensure expected behavior, it is
+     * recommended that any variables that will be used across the longjmp are
+     * declared as volatile, are heap allocated, or are global in scope.
+     *
+     * For C++ applications, whether stack variables are automatically
+     * destructed when leaving stack frames via longjmp is undefined. For this
+     * reason and the above, it is highly recommended to instead use
+     * #FENIX_RESUME_THROW for C++ applications.
+     */
     FENIX_RESUME_JUMP,
     //!Return the error code inline
     FENIX_RESUME_RETURN,
     //!Throw a fenix::CommException
-    FENIX_RESUME_THROW
+    FENIX_RESUME_THROW,
+
+    //!Not a valid option
+    FENIX_RESUME_MODE_MAXCODE
 } Fenix_Resume_mode;
 
 /**
@@ -181,87 +236,97 @@ typedef enum {
     //!Print error and continue without handling
     FENIX_UNHANDLED_PRINT,
     //!Print error and abort Fenix's world (default)
-    FENIX_UNHANDLED_ABORT
+    FENIX_UNHANDLED_ABORT,
+
+    //!Not a valid option
+    FENIX_UNHANDLED_MODE_MAXCODE
 } Fenix_Unhandled_mode;
 
 /**
- * @fn void Fenix_Init(int* role, MPI_Comm comm, MPI_Comm* newcomm, int** argc, char*** argv, int spare_ranks, int spawn, MPI_Info info, int* error);
+ * @brief Options for dealing with CommExceptions generated in callbacks
+ */
+typedef enum {
+    //!CommExceptions are allowed to propagate out of callbacks
+    FENIX_CALLBACK_EXCEPTION_RETHROW,
+    //!CommExceptions from callbacks are squashed
+    FENIX_CALLBACK_EXCEPTION_SQUASH,
+
+    //!Not a valid option
+    FENIX_CALLBACK_EXCEPTION_MODE_MAXCODE
+} Fenix_Callback_exception_mode;
+
+/**
+ * @fn void Fenix_Init(int* role, MPI_Comm comm, MPI_Comm* newcomm, int** argc, char*** argv, int spare_ranks, int* error)
  * @brief Build a resilient communicator and set the restart point.
  *
- * This function must be called by all ranks in \c comm, after MPI initialization. All calling ranks must
- * pass the same values for the parameters \c comm, \c spare_ranks, \c spawn, and \c info. \c Fenix_init
- * must be called exactly once by each rank. This function is used (1) to activate the Fenix library, (2)
- * to specify extra resources in case of rank failure, and (3) to create a logical resumption point in case
- * of rank failure.
+ * This function must be called by all ranks in \c comm, after MPI
+ * initialization. All calling ranks must pass the same values for the
+ * parameters \c comm and \c spare_ranks. \c Fenix_init must be called exactly
+ * once by each rank. This function is used
+ *   (1) to activate the Fenix library,
+ *   (2) to specify extra resources in case of rank failure, and
+ *   (3) to create a logical resume point for when #FENIX_RESUME_JUMP is set
  *
- * For C, the program may rely on the the state of any variables defined and set before the call to \c Fenix_Init.
- * But note that the code executed before \c Fenix_Init is executed by all ranks in the system (including spare 
- * ranks, see below). For C++, the state of objects declared before \c Fenix_Init but within the same scope as
- * \c Fenix_Init is compiler-dependant, and it is recommended to place \c Fenix_Init within a subscope exluding
- * any variables expected to no be destructed.
+ * Note that this function uses #FENIX_RESUME_JUMP by default, which exposes
+ * applications to various undefined behaviors if they do not take care about
+ * how variables are used before and after the jump. See #FENIX_RESUME_JUMP for
+ * more information.
  *
- * It is recommended to access argc and argv only after executin \c Fenix_Init, since command line arguments
- * passed to this function that apply to Fenix may be removed by \c Fenix_Init.
+ * It is recommended to access argc and argv only after executing \c Fenix_Init,
+ * since command line arguments passed to this function that apply to Fenix may
+ * be removed by \c Fenix_Init.
  *
- * \c Fenix_Init is blocking in the following sense. If it is entered for the first time via a regular, explicit
- * function call, it must be entered by all ranks in communicator \c comm. If it is entered after an error 
- * intercepted by Fenix (it if the default execution resumption point, see _info below), no ranks are allowed 
- * to exit from it until all *non-failed* ranks have returned control to it. **Note**: Typically control is  
- * returned automatically through revocation of the resilient communicator, which means ranks which have long 
- * delays between MPI function calls or ranks which only use communicators unaffected by failure may lead to
- * long delays between a failure and its recovery.
+ * \c Fenix_Init is blocking in the following sense. If it is entered for the
+ * first time via a regular, explicit function call, it must be entered by all
+ * ranks in communicator \c comm. If it is entered after an error intercepted by
+ * Fenix (due to #FENIX_RESUME_MODE #FENIX_RESUME_JUMP), no ranks are allowed to
+ * exit from it until all *non-failed* ranks have returned control to it.
+ * **Note**: Typically, control is returned automatically through revocation of
+ * the resilient communicator, which means ranks that have long delays between
+ * MPI function calls or ranks that only use communicators unaffected by failure
+ * may lead to long delays between a failure and its recovery. See
+ * #Fenix_Process_detect_failures for a way to improve this behavior.
  *
- * Ranks to be used as spare ranks by Fenix will be available to the application only before \c Fenix_Init,
- * or after they are used to replace a failed rank, in which case they turn into active ranks. This document
- * refers to the latter as \c RECOVERED ranks (see #Fenix_Rank_role). Note that all spare
- * ranks that have not been used to recover from failures (and, therefore, are still reserved by Fenix and kept 
- * inside \c Fenix_Init) will automatically call \c MPI_Finalize and exit when all active ranks have entered the 
+ * Ranks to be used as spare ranks by Fenix will be available to the application
+ * only before \c Fenix_Init or after they are used to replace a failed rank (in
+ * which case they become active ranks). This document refers to the latter as
+ * \c RECOVERED ranks (see #Fenix_Rank_role). Note that all spare ranks that
+ * have not been used to recover from failures (and, therefore, are still
+ * reserved by Fenix and kept inside \c Fenix_Init) will automatically call
+ * \c MPI_Finalize and exit when all active ranks have entered the
  * #Fenix_Finalize call.
  *
- * No Fenix functions may be called before \c Fenix_Init, except #Fenix_Initialized.
+ * No Fenix functions may be called before \c Fenix_Init, except
+ * #Fenix_Initialized and #Fenix_set_option.
  *
- * @param[out] role The current role of this rank (see #Fenix_Rank_role)
- * @param[in] comm The base communicator to construct a resilient communicator from,
- *   which must include any spare ranks (see below) the user deems necessary.
- *   MPI_COMM_WORLDis a valid value, but MPI_COMM_SELF is not.
- * @param[out] newcomm Resilient output communicator, managed by Fenix and derived 
- *   from comm, to be used by the application instead of comm.
+ * @param[out]   role The current #Fenix_Rank_role of this rank
+ * @param[in]    comm Communicator to construct the resilient communicator from
+ * @param[out]   newcomm Resilient output communicator
  * @param[inout] argc Pointer to application main's argc parameter
  * @param[inout] argv Pointer to application main's argv parameter
- * @param[in] spare_ranks The number of ranks in comm that are exempted by Fenix
- *   in the construction of the resilient communicator by Fenix_Init. These ranks
- *   are kept in reserve to substitute for failed ranks. Failed ranks in resilient
- *   communicators are replaced by spare or spawned ranks.
- * @param[in] spawn *Unimplemented*: Whether to enable spawning new ranks to replace
- *   failed ranks when spares are unavailable.
- * @param[in] info Fenix recovery configuration parameters, may be MPI_INFO_NULL
- *   "FENIX_RESUME_MODE" key is used to indicate where execution should resume upon 
- *   rank failure for all active (non-spare) ranks in any resilient communicators, not only for 
- *   those ranks in communicators that failed. The value should be a string with the name of a
- *   Fenix_Resume_mode enum value.
- *   "FENIX_UNHANDLED_MODE" key is used to indicate how Fenix should handle error values
- *   returned by MPI functions that are unrelated to failed processes. The value should be
- *   a string with the name of a Fenix_Unhandled_mode enum value.
- * @param[out] error The return status of \c Fenix_Init<br>
- *   Used to signal that a non-fatal error or special condition was encountered in the execution of
- *   Fenix_Init, or FENIX_SUCCESS otherwise. It has the same value across all ranks released by 
- *   Fenix_Init. If spawning is explicitly disabled (_spawn equals false) and spare ranks have been 
- *   depleted, Fenix will repair resilience communicators by shrinking them and will report such 
- *   shrinkage in this return parameter through the value FENIX_WARNING_SPARE_RANKS_DEPLETED.
+ * @param[in]    spare_ranks Number of ranks in comm to reserve from newcomm
+ *   These ranks are reserved to substitute for failed ranks.
+ * @param[out]   error The return status of \c Fenix_Init<br>
+ *   Used to signal that a non-fatal error or special condition was encountered
+ *   in the execution of Fenix_Init, or FENIX_SUCCESS otherwise. It has the same
+ *   value across all ranks released by Fenix_Init.
+ *   If spawning is not enabled (#FENIX_RECOVERY_MODE is not
+ *   #FENIX_RECOVERY_SPAWN) and spare ranks have been depleted, Fenix will
+ *   repair resilience communicators by shrinking them and will report such
+ *   shrinkage in this return parameter through the value
+ *   FENIX_WARNING_SPARE_RANKS_DEPLETED.
  */
 
 //!@internal
-#define Fenix_Init(_role, _comm, _newcomm, _argc, _argv, _spare_ranks,  \
-                   _spawn, _info, _error)                               \
-    {                                                                   \
-        static jmp_buf bufjmp;                                          \
-        *(_role) = __fenix_preinit(_role, _comm, _newcomm, _argc,       \
-                                   _argv, _spare_ranks, _spawn, _info,  \
-                                   _error, &bufjmp);                    \
-        setjmp(bufjmp);                                                 \
-        __fenix_postinit();                                             \
+#define Fenix_Init(_role, _comm, _newcomm, _argc, _argv, _spare_ranks, _err)   \
+    {                                                                          \
+        static jmp_buf bufjmp;                                                 \
+        *(_role) = __fenix_preinit(                                            \
+            _role, _comm, _newcomm, _argc, _argv, _spare_ranks, _err, &bufjmp  \
+        );                                                                     \
+        setjmp(bufjmp);                                                        \
+        __fenix_postinit();                                                    \
     }
-
 
 /**
  * @brief Sets flag to true if Fenix_Init has been called, else false.
@@ -269,6 +334,35 @@ typedef enum {
  * @returnstatus
  */
 int Fenix_Initialized(int *flag);
+
+/**
+ * @brief Configure a global Fenix setting.
+ * @qualifier local
+ *
+ * Each #Fenix_Setting_name will describe its function and valid options.
+ *
+ * If called prior to Fenix_Init, the setting will apply to future Fenix_Inits.
+ * Settings configured during initialization override prior configurations.
+ *
+ * Unless otherwise noted, it is undefined behavior if settings are not
+ * consistent across all ranks.
+ *
+ * @param[in] setting The #Fenix_Setting_name to configure.
+ * @param[in] option  The option to configure setting to.
+ * @returnstatus
+ */
+int Fenix_set_option(Fenix_Setting_name setting, int option);
+
+/**
+ * @brief Get the current option for a Fenix setting.
+ *
+ * Each #Fenix_Setting_name will describe its function and possible options.
+ *
+ * @param[in]  setting The #Fenix_Setting_name to configure.
+ * @param[out] option  The current option of the setting.
+ * @returnstatus
+ */
+int Fenix_get_option(Fenix_Setting_name setting, int option);
 
 /**
  * @brief Register a callback to be invoked after failure process recovery.

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -54,7 +54,6 @@
 //@HEADER
 */
 
-
 #ifndef __FENIX_HPP__
 #define __FENIX_HPP__
 
@@ -68,61 +67,58 @@
 
 namespace fenix {
 
-using Role = Fenix_Rank_role;
+using Role                    = Fenix_Rank_role;
 constexpr Role INITIAL_RANK   = FENIX_ROLE_INITIAL_RANK;
 constexpr Role RECOVERED_RANK = FENIX_ROLE_RECOVERED_RANK;
 constexpr Role SURVIVOR_RANK  = FENIX_ROLE_SURVIVOR_RANK;
 
-using SettingName = Fenix_Setting_name;
+using SettingName                             = Fenix_Setting_name;
 constexpr SettingName RECOVERY_MODE           = FENIX_RECOVERY_MODE;
 constexpr SettingName RESUME_MODE             = FENIX_RESUME_MODE;
 constexpr SettingName UNHANDLED_MODE          = FENIX_UNHANDLED_MODE;
 constexpr SettingName CALLBACK_EXCEPTION_MODE = FENIX_CALLBACK_EXCEPTION_MODE;
 
-using RecoveryMode = Fenix_Recovery_mode;
+using RecoveryMode            = Fenix_Recovery_mode;
 constexpr RecoveryMode IGNORE = FENIX_RECOVERY_IGNORE;
 constexpr RecoveryMode NOOP   = FENIX_RECOVERY_NOOP;
 constexpr RecoveryMode REPAIR = FENIX_RECOVERY_REPAIR;
 constexpr RecoveryMode SPAWN  = FENIX_RECOVERY_SPAWN;
 
-using ResumeMode = Fenix_Resume_mode;
+using ResumeMode            = Fenix_Resume_mode;
 constexpr ResumeMode JUMP   = FENIX_RESUME_JUMP;
 constexpr ResumeMode RETURN = FENIX_RESUME_RETURN;
 constexpr ResumeMode THROW  = FENIX_RESUME_THROW;
 
-using CallbackExceptionMode = Fenix_Callback_exception_mode;
+using CallbackExceptionMode             = Fenix_Callback_exception_mode;
 constexpr CallbackExceptionMode RETHROW = FENIX_CALLBACK_EXCEPTION_RETHROW;
-constexpr CallbackExceptionMode SQUASH = FENIX_CALLBACK_EXCEPTION_SQUASH;
+constexpr CallbackExceptionMode SQUASH  = FENIX_CALLBACK_EXCEPTION_SQUASH;
 
-using UnhandledMode = Fenix_Unhandled_mode;
+using UnhandledMode            = Fenix_Unhandled_mode;
 constexpr UnhandledMode SILENT = FENIX_UNHANDLED_SILENT;
 constexpr UnhandledMode PRINT  = FENIX_UNHANDLED_PRINT;
 constexpr UnhandledMode ABORT  = FENIX_UNHANDLED_ABORT;
 
-enum CallbackLocation {
-    PRE_RECOVERY,
-    POST_RECOVERY
-};
+enum CallbackLocation { PRE_RECOVERY, POST_RECOVERY };
 
 namespace args {
 struct FenixInitArgs {
-    int* role                                       = nullptr;
-    MPI_Comm in_comm                                = MPI_COMM_WORLD;
-    MPI_Comm* out_comm                              = nullptr;
-    int* argc                                       = nullptr;
-    char*** argv                                    = nullptr;
-    int spares                                      = 0;
-    int* err                                        = nullptr;
+  int* role          = nullptr;
+  MPI_Comm in_comm   = MPI_COMM_WORLD;
+  MPI_Comm* out_comm = nullptr;
+  int* argc          = nullptr;
+  char*** argv       = nullptr;
+  int spares         = 0;
+  int* err           = nullptr;
 };
 }
 
 void init(const args::FenixInitArgs args);
 
 //!@brief overload of #Fenix_set_option
-void set_option(SettingName setting, int option);
+void set_option(SettingName setting, unsigned option);
 
 //!@brief overload of #Fenix_get_option returning the option directly
-int get_option(SettingName setting);
+unsigned get_option(SettingName setting);
 
 //!@brief Throw an exception for the most recent fault. Helpful for spares.
 void throw_exception();
@@ -140,7 +136,7 @@ using FenixCallbackFunc = std::function<void(MPI_Comm, int)>;
 
 //!@brief Overload of #Fenix_Callback_register
 int callback_register(
-    FenixCallbackFunc callback, CallbackLocation loc = POST_RECOVERY
+  FenixCallbackFunc callback, CallbackLocation loc = POST_RECOVERY
 );
 
 //@!brief Overload of #Fenix_Callback_pop
@@ -171,8 +167,8 @@ extern DataSubset SUBSET_IGNORE;
 
 //@!brief Overload of #Fenix_Data_group_create
 int group_create(
-    int group_id, MPI_Comm comm, int start_time_stamp, int depth,
-    int policy_name, void* policy_value, int* flag
+  int group_id, MPI_Comm comm, int start_time_stamp, int depth, int policy_name,
+  void* policy_value, int* flag
 );
 
 //@!brief Overload of #Fenix_Data_group_created
@@ -180,7 +176,7 @@ bool group_created(int group_id);
 
 //@!brief Overload of #Fenix_Data_member_create
 int member_create(
-    int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
 );
 
 //@!brief Overload of #Fenix_Data_member_created
@@ -194,26 +190,24 @@ int member_storev(int group_id, int member_id, const DataSubset& subset);
 
 //!@brief Overload of #Fenix_Data_member_istore
 int member_istore(
-    int group_id, int member_id, const DataSubset& subset,
-    Fenix_Request *request
+  int group_id, int member_id, const DataSubset& subset, Fenix_Request* request
 );
 
 //!@brief Overload of #Fenix_Data_member_istorev
 int member_istorev(
-    int group_id, int member_id, const DataSubset& subset,
-    Fenix_Request *request
+  int group_id, int member_id, const DataSubset& subset, Fenix_Request* request
 );
 
 //!@brief Overload of #Fenix_Data_member_restore
 int member_restore(
-    int group_id, int member_id, void *target_buffer, int max_length,
-    int time_stamp, DataSubset& data_found
+  int group_id, int member_id, void* target_buffer, int max_length,
+  int time_stamp, DataSubset& data_found
 );
 
 //!@brief Overload of #Fenix_Data_member_lrestore
 int member_lrestore(
-    int group_id, int member_id, void *target_buffer, int max_length,
-    int time_stamp, DataSubset& data_found
+  int group_id, int member_id, void* target_buffer, int max_length,
+  int time_stamp, DataSubset& data_found
 );
 
 //@!brief overload of #Fenix_Data_commit

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -73,15 +73,26 @@ constexpr Role INITIAL_RANK   = FENIX_ROLE_INITIAL_RANK;
 constexpr Role RECOVERED_RANK = FENIX_ROLE_RECOVERED_RANK;
 constexpr Role SURVIVOR_RANK  = FENIX_ROLE_SURVIVOR_RANK;
 
+using SettingName = Fenix_Setting_name;
+constexpr SettingName RECOVERY_MODE           = FENIX_RECOVERY_MODE;
+constexpr SettingName RESUME_MODE             = FENIX_RESUME_MODE;
+constexpr SettingName UNHANDLED_MODE          = FENIX_UNHANDLED_MODE;
+constexpr SettingName CALLBACK_EXCEPTION_MODE = FENIX_CALLBACK_EXCEPTION_MODE;
+
+using RecoveryMode = Fenix_Recovery_mode;
+constexpr RecoveryMode IGNORE = FENIX_RECOVERY_IGNORE;
+constexpr RecoveryMode NOOP   = FENIX_RECOVERY_NOOP;
+constexpr RecoveryMode REPAIR = FENIX_RECOVERY_REPAIR;
+constexpr RecoveryMode SPAWN  = FENIX_RECOVERY_SPAWN;
+
 using ResumeMode = Fenix_Resume_mode;
 constexpr ResumeMode JUMP   = FENIX_RESUME_JUMP;
 constexpr ResumeMode RETURN = FENIX_RESUME_RETURN;
 constexpr ResumeMode THROW  = FENIX_RESUME_THROW;
 
-enum CallbackExceptionMode {
-    RETHROW,
-    SQUASH
-};
+using CallbackExceptionMode = Fenix_Callback_exception_mode;
+constexpr CallbackExceptionMode RETHROW = FENIX_CALLBACK_EXCEPTION_RETHROW;
+constexpr CallbackExceptionMode SQUASH = FENIX_CALLBACK_EXCEPTION_SQUASH;
 
 using UnhandledMode = Fenix_Unhandled_mode;
 constexpr UnhandledMode SILENT = FENIX_UNHANDLED_SILENT;
@@ -101,15 +112,17 @@ struct FenixInitArgs {
     int* argc                                       = nullptr;
     char*** argv                                    = nullptr;
     int spares                                      = 0;
-    int spawn                                       = 0;
-    ResumeMode resume_mode                          = THROW;
-    CallbackExceptionMode callback_exception_mode   = RETHROW;
-    UnhandledMode unhandled_mode                    = ABORT;
     int* err                                        = nullptr;
 };
 }
 
 void init(const args::FenixInitArgs args);
+
+//!@brief overload of #Fenix_set_option
+void set_option(SettingName setting, int option);
+
+//!@brief overload of #Fenix_get_option returning the option directly
+int get_option(SettingName setting);
 
 //!@brief Throw an exception for the most recent fault. Helpful for spares.
 void throw_exception();

--- a/include/fenix_ext.hpp
+++ b/include/fenix_ext.hpp
@@ -65,18 +65,23 @@
 #include "fenix_data_group.hpp"
 
 namespace fenix {
+struct fenix_t {
+    struct Settings {
+        int recovery           = -1;
+        int resume             = -1;
+        int callback_exception = -1;
+        int unhandled          = -1;
+    };
+    // Global settings specified by the user prior to initializing
+    inline static Settings user_defaults = {-1, -1, -1, -1};
+    // Global Fenix settings
+    Settings settings {REPAIR, JUMP, SQUASH, ABORT};
 
-typedef struct {
-    int num_inital_ranks;        // Keeps the global MPI rank ID at Fenix_init
+    int num_initial_ranks;       // Keeps the global MPI rank ID at Fenix_init
     int num_survivor_ranks = 0;  // Keeps the global information on the number of survived MPI ranks after failure
     int num_recovered_ranks = 0; // Keeps the number of spare ranks brought into MPI communicator recovery
     int spare_ranks;             // Spare ranks entered by user to repair failed ranks
     
-    ResumeMode resume_mode = JUMP;
-    CallbackExceptionMode callback_exception_mode = RETHROW;
-    UnhandledMode unhandled_mode = ABORT;
-    bool ignore_errs = false;       // Temporarily ignore all errors & recovery
-    int spawn_policy;             // Indicate dynamic process spawning
     jmp_buf *recover_environment; // Calling environment to fill the jmp_buf structure
 
     int mpi_fail_code = MPI_SUCCESS;
@@ -111,9 +116,8 @@ typedef struct {
     MPI_Errhandler mpi_errhandler; // Our custom error handler
 
     fenix::data::fenix_data_recovery_t *data_recovery = nullptr;   // Global pointer for Fenix Data Recovery Data Structure
-} fenix_t;
-
-}
+};
+} // namespace fenix
 
 inline fenix::fenix_t fenix_rt;
 #endif // __FENIX_EXT_H__

--- a/include/fenix_ext.hpp
+++ b/include/fenix_ext.hpp
@@ -65,59 +65,63 @@
 #include "fenix_data_group.hpp"
 
 namespace fenix {
-struct fenix_t {
-    struct Settings {
-        int recovery           = -1;
-        int resume             = -1;
-        int callback_exception = -1;
-        int unhandled          = -1;
-    };
-    // Global settings specified by the user prior to initializing
-    inline static Settings user_defaults = {-1, -1, -1, -1};
-    // Global Fenix settings
-    Settings settings {REPAIR, JUMP, SQUASH, ABORT};
 
-    int num_initial_ranks;       // Keeps the global MPI rank ID at Fenix_init
-    int num_survivor_ranks = 0;  // Keeps the global information on the number of survived MPI ranks after failure
-    int num_recovered_ranks = 0; // Keeps the number of spare ranks brought into MPI communicator recovery
-    int spare_ranks;             // Spare ranks entered by user to repair failed ranks
-    
-    jmp_buf *recover_environment; // Calling environment to fill the jmp_buf structure
-
-    int mpi_fail_code = MPI_SUCCESS;
-    int repair_result = FENIX_SUCCESS; // Internal variable to store the result of MPI comm repair
-    int role = FENIX_ROLE_INITIAL_RANK;
-
-    int fenix_init_flag = false;
-    int finalized = false;
-
-    int fail_world_size = 0;
-    int* fail_world = nullptr;
-
-    //Save the pointer to role and error of Fenix_Init
-    int *ret_role = nullptr;
-    int *ret_error = nullptr;
-
-    std::unordered_map<
-        CallbackLocation, std::vector<FenixCallbackFunc>
-    > callbacks;
-    fenix_debug_opt_t options; // This is reserved to store the user options
-
-    MPI_Comm *world;      // Duplicate of comm provided by user
-    MPI_Comm *user_world; // User-facing comm with repaired ranks and no spares
-    MPI_Comm new_world;   // Internal duplicate of user_world
-    int new_world_exists = false, user_world_exists = false;
-   
-    //Values used for Fenix_Process_detect_failures
-    int dummy_recv_buffer;
-    MPI_Request check_failures_req;
-    
-    MPI_Op   agree_op;             // Global agreement call for Fenix data recovery API
-    MPI_Errhandler mpi_errhandler; // Our custom error handler
-
-    fenix::data::fenix_data_recovery_t *data_recovery = nullptr;   // Global pointer for Fenix Data Recovery Data Structure
+// Fenix's global settings, configurable before initialization
+struct Settings {
+  RecoveryMode recovery              = REPAIR;
+  // Defaults to JUMP if a jump_buf provided, else THROW
+  ResumeMode resume                  = FENIX_RESUME_MODE_MAXCODE;
+  CallbackExceptionMode cb_exception = SQUASH;
+  UnhandledMode unhandled            = ABORT;
 };
-} // namespace fenix
+
+// Configurations before init change this
+inline Settings fenix_default_settings;
+
+struct fenix_t {
+  // Global Fenix settings
+  Settings settings;
+
+  int num_initial_ranks;
+  int num_survivor_ranks  = 0; // As of last failure
+  int num_recovered_ranks = 0; // As of last failure
+  int spare_ranks;             // Spare ranks entered by user
+
+  jmp_buf* recover_environment; // for FENIX_RESUME_JUMP
+
+  int mpi_fail_code = MPI_SUCCESS;
+  int repair_result = FENIX_SUCCESS; // Result of MPI comm repair
+  int role          = FENIX_ROLE_INITIAL_RANK;
+
+  int fenix_init_flag = false;
+  int finalized       = false;
+
+  int fail_world_size = 0;
+  int* fail_world     = nullptr;
+
+  //Save the pointer to role and error of Fenix_Init
+  int* ret_role  = nullptr;
+  int* ret_error = nullptr;
+
+  std::unordered_map<CallbackLocation, std::vector<FenixCallbackFunc>>
+    callbacks;
+  fenix_debug_opt_t options; // This is reserved to store the user options
+
+  MPI_Comm* world;      // Duplicate of comm provided by user
+  MPI_Comm* user_world; // User-facing comm with repaired ranks and no spares
+  MPI_Comm new_world;   // Internal duplicate of user_world
+  int new_world_exists = false, user_world_exists = false;
+
+  //Values used for Fenix_Process_detect_failures
+  int dummy_recv_buffer;
+  MPI_Request check_failures_req;
+
+  MPI_Op agree_op;               // Global agreement call for data recovery API
+  MPI_Errhandler mpi_errhandler; // Our custom error handler
+
+  fenix::data::fenix_data_recovery_t* data_recovery = nullptr;
+};
 
 inline fenix::fenix_t fenix_rt;
+} // namespace fenix
 #endif // __FENIX_EXT_H__

--- a/include/fenix_init.h
+++ b/include/fenix_init.h
@@ -64,7 +64,7 @@
 extern "C" {
 #endif
 
-int __fenix_preinit(int *, MPI_Comm, MPI_Comm *, int *, char ***, int, int, MPI_Info, int *, jmp_buf *);
+int __fenix_preinit(int *, MPI_Comm, MPI_Comm *, int *, char ***, int, int *, jmp_buf *);
 
 
 void __fenix_postinit();

--- a/include/fenix_util.hpp
+++ b/include/fenix_util.hpp
@@ -134,7 +134,9 @@ struct ScopedOption {
   ScopedOption(SettingName m_setting, int new_option) : setting(m_setting) {
     set_option(setting, new_option);
   }
-  ~ScopedOption() { if (!fenix_rt.finalized) set_option(setting, old); }
+  ~ScopedOption() {
+    if (!fenix_rt.finalized) set_option(setting, old);
+  }
 
   // No moving or copying scoped options, things would get complicated.
   ScopedOption(const ScopedOption&) = delete;
@@ -146,14 +148,12 @@ struct ScopedOption {
 
 // Default error handling for inside the Fenix runtime.
 struct ScopedDefaultRuntimeOptions {
-  ScopedOption resume{RESUME_MODE, THROW},
-               unhandled {UNHANDLED_MODE, ABORT};
+  ScopedOption resume{RESUME_MODE, THROW}, unhandled{UNHANDLED_MODE, ABORT};
 };
 
 // Helper for MPI_ERRORS_RETURN-like error handling
 struct ScopedIgnoreAndReturn {
-  ScopedOption recovery{RECOVERY_MODE, IGNORE},
-               resume{RESUME_MODE, RETURN};
+  ScopedOption recovery{RECOVERY_MODE, IGNORE}, resume{RESUME_MODE, RETURN};
 };
 
 } // namespace fenix::util

--- a/include/fenix_util.hpp
+++ b/include/fenix_util.hpp
@@ -128,36 +128,34 @@ inline int comm_rank(MPI_Comm c) {
   return ret;
 }
 
-// ScopedSetting struct holds the old value and automatically reverts in
-// destructor, so settings changes revert even when exceptions are thrown.
-template<typename T>
-struct ScopedSetting {
-  ScopedSetting(T& m_setting, T val) : setting(m_setting) { setting = val; }
-  ~ScopedSetting() { setting = old_val; }
- private:
-  T& setting;
-  const T old_val = setting;
-};
+// ScopedOptions hold the old option and revert to it in their destructors, so
+// changes revert even when exceptions are thrown.
+struct ScopedOption {
+  ScopedOption(SettingName m_setting, int new_option) : setting(m_setting) {
+    set_option(setting, new_option);
+  }
+  ~ScopedOption() { if (!fenix_rt.finalized) set_option(setting, old); }
 
-struct ScopedIgnoreErrs : public ScopedSetting<bool> {
-  ScopedIgnoreErrs(bool ignore_errs)
-    : ScopedSetting(fenix_rt.ignore_errs, ignore_errs) {}
-};
-struct ScopedResumeMode : public ScopedSetting<ResumeMode> {
-  ScopedResumeMode(ResumeMode resume_mode)
-    : ScopedSetting(fenix_rt.resume_mode, resume_mode) {}
-};
-struct ScopedUnhandledMode : public ScopedSetting<UnhandledMode> {
-  ScopedUnhandledMode(UnhandledMode unhandled_mode)
-    : ScopedSetting(fenix_rt.unhandled_mode, unhandled_mode) {}
+  // No moving or copying scoped options, things would get complicated.
+  ScopedOption(const ScopedOption&) = delete;
+  ScopedOption(ScopedOption&&) = delete;
+
+  const SettingName setting;
+  const int old = get_option(setting);
 };
 
 // Default error handling for inside the Fenix runtime.
-struct ScopedDefaultRuntimeSettings {
-  const ScopedIgnoreErrs    ignore_errs{ false };
-  const ScopedResumeMode    resume_mode{ THROW };
-  const ScopedUnhandledMode unhandled_mode{ ABORT };
+struct ScopedDefaultRuntimeOptions {
+  ScopedOption resume{RESUME_MODE, THROW},
+               unhandled {UNHANDLED_MODE, ABORT};
 };
+
+// Helper for MPI_ERRORS_RETURN-like error handling
+struct ScopedIgnoreAndReturn {
+  ScopedOption recovery{RECOVERY_MODE, IGNORE},
+               resume{RESUME_MODE, RETURN};
+};
+
 } // namespace fenix::util
 
 #define RUNTIME_EXCEPTION_HANDLER              \
@@ -167,7 +165,7 @@ struct ScopedDefaultRuntimeSettings {
 
 #define COMM_EXCEPTION_HANDLER                                     \
   } catch (const fenix::CommException& e) {                        \
-    switch(fenix_rt.resume_mode) {                                 \
+    switch(fenix_rt.settings.resume) {                             \
       case fenix::JUMP: longjmp(*fenix_rt.recover_environment, 1); \
       case fenix::THROW: throw;                                    \
       case fenix::RETURN:                                          \
@@ -176,10 +174,10 @@ struct ScopedDefaultRuntimeSettings {
     return FENIX_ERROR_CANCELLED;                                  \
   }
 
-#define FENIX_CPP_API_BEGIN                                \
-  try {                                                    \
-    fenix::util::ScopedDefaultRuntimeSettings _scoped_drs; \
-    assert(fenix_rt.fenix_init_flag);
+#define FENIX_CPP_API_BEGIN                                                    \
+  try {                                                                        \
+    fenix::util::ScopedDefaultRuntimeOptions _scoped_dro;                      \
+    if (!fenix_rt.fenix_init_flag) FENIX_THROW(FENIX_ERROR_UNINITIALIZED);
 
 #define FENIX_C_API_BEGIN FENIX_CPP_API_BEGIN
 

--- a/src/fenix.cpp
+++ b/src/fenix.cpp
@@ -66,9 +66,9 @@ const Fenix_Data_subset FENIX_DATA_SUBSET_FULL = {
   new DataSubset(DataSubset::MAX)
 };
 const Fenix_Data_subset FENIX_DATA_SUBSET_EMPTY = {new DataSubset()};
-Fenix_Data_subset* FENIX_DATA_SUBSET_IGNORE = NULL;
+Fenix_Data_subset* FENIX_DATA_SUBSET_IGNORE     = NULL;
 
-int Fenix_set_option(Fenix_Setting_name setting, int option) {
+int Fenix_set_option(Fenix_Setting_name setting, unsigned option) {
   // This function gets special handling, since it can be called before init
 #ifdef FENIC_C_CATCH_RUNTIME_EXCEPTIONS
   try {
@@ -83,7 +83,7 @@ int Fenix_set_option(Fenix_Setting_name setting, int option) {
 #endif
 }
 
-int Fenix_get_option(Fenix_Setting_name setting, int* option) {
+int Fenix_get_option(Fenix_Setting_name setting, unsigned* option) {
   FENIX_C_API_BEGIN
   *option = get_option(setting);
   return FENIX_SUCCESS;
@@ -162,24 +162,30 @@ int Fenix_get_nspare() {
 
 namespace fenix {
 
+template <typename T>
+static void set_opt_enum(T& t, unsigned opt, unsigned opt_oob) {
+  static_assert(std::is_enum_v<T>);
+  if (opt >= opt_oob) FENIX_THROW(FENIX_ERROR_INVALID_SETTING_OPTION);
+  t = static_cast<T>(opt);
+}
+
 #define SET_OPTION_CASE(name, var)                                             \
   case name##_MODE:                                                            \
-    if (option >= FENIX_##name##_MODE_MAXCODE) {                               \
-      FENIX_THROW(FENIX_ERROR_INVALID_SETTING_OPTION);                         \
-    }                                                                          \
-    if (!fenix_rt.fenix_init_flag) fenix_rt.user_defaults.var = option;        \
-    else fenix_rt.settings.var = option;                                       \
+    set_opt_enum(settings.var, option, FENIX_##name##_MODE_MAXCODE);           \
     break
 
-void set_option(SettingName setting, int option) {
+void set_option(SettingName setting, unsigned option) {
   if (setting >= FENIX_SETTING_NAME_MAXCODE) {
     FENIX_THROW(FENIX_ERROR_INVALID_SETTING_NAME);
   }
+
+  Settings& settings =
+    fenix_rt.fenix_init_flag ? fenix_rt.settings : fenix_default_settings;
   switch (setting) {
     SET_OPTION_CASE(RECOVERY, recovery);
     SET_OPTION_CASE(RESUME, resume);
     SET_OPTION_CASE(UNHANDLED, unhandled);
-    SET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
+    SET_OPTION_CASE(CALLBACK_EXCEPTION, cb_exception);
   default:
     FENIX_THROW(FENIX_ERROR_INTERN);
   }
@@ -189,13 +195,13 @@ void set_option(SettingName setting, int option) {
   case n##_MODE:                                                               \
     return fenix_rt.settings.v
 
-int get_option(SettingName setting) {
+unsigned get_option(SettingName setting) {
   if (!fenix_rt.fenix_init_flag) FENIX_THROW(FENIX_ERROR_UNINITIALIZED);
   switch (setting) {
     GET_OPTION_CASE(RECOVERY, recovery);
     GET_OPTION_CASE(RESUME, resume);
     GET_OPTION_CASE(UNHANDLED, unhandled);
-    GET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
+    GET_OPTION_CASE(CALLBACK_EXCEPTION, cb_exception);
   default:
     FENIX_THROW(FENIX_ERROR_INTERN);
   }
@@ -230,9 +236,9 @@ std::vector<int> fail_list() {
 bool initialized() { return fenix_rt.fenix_init_flag; }
 
 namespace data {
-const DataSubset SUBSET_FULL = {{0, fenix::DataSubset::MAX}};
+const DataSubset SUBSET_FULL  = {{0, fenix::DataSubset::MAX}};
 const DataSubset SUBSET_EMPTY = {};
-DataSubset SUBSET_IGNORE = SUBSET_EMPTY;
+DataSubset SUBSET_IGNORE      = SUBSET_EMPTY;
 } // namespace data
 
 } //namespace fenix
@@ -316,7 +322,7 @@ int Fenix_Data_member_restore(
 ) {
   FENIX_C_API_BEGIN
   DataSubset* s = new DataSubset();
-  int ret = member_restore(
+  int ret       = member_restore(
     group_id, member_id, target_buffer, max_count, time_stamp, *s
   );
   if (data_found == nullptr) {
@@ -334,7 +340,7 @@ int Fenix_Data_member_lrestore(
 ) {
   FENIX_C_API_BEGIN
   DataSubset* s = new DataSubset();
-  int ret = member_lrestore(
+  int ret       = member_lrestore(
     group_id, member_id, target_buffer, max_count, time_stamp, *s
   );
   if (data_found == nullptr) {

--- a/src/fenix.cpp
+++ b/src/fenix.cpp
@@ -74,7 +74,7 @@ int Fenix_set_option(Fenix_Setting_name setting, int option) {
   try {
     set_option(setting, option);
     return FENIX_SUCCESS;
-  } catch (const fenix::RuntimeException& e){
+  } catch (const fenix::RuntimeException& e) {
     return e.error;
   }
 #else
@@ -167,8 +167,8 @@ namespace fenix {
     if (option >= FENIX_##name##_MODE_MAXCODE) {                               \
       FENIX_THROW(FENIX_ERROR_INVALID_SETTING_OPTION);                         \
     }                                                                          \
-    if (!fenix_rt.fenix_init_flag) fenix_rt.user_defaults. var = option;       \
-    else fenix_rt.settings. var = option;                                      \
+    if (!fenix_rt.fenix_init_flag) fenix_rt.user_defaults.var = option;        \
+    else fenix_rt.settings.var = option;                                       \
     break
 
 void set_option(SettingName setting, int option) {
@@ -176,24 +176,28 @@ void set_option(SettingName setting, int option) {
     FENIX_THROW(FENIX_ERROR_INVALID_SETTING_NAME);
   }
   switch (setting) {
-  SET_OPTION_CASE(RECOVERY, recovery);
-  SET_OPTION_CASE(RESUME, resume);
-  SET_OPTION_CASE(UNHANDLED, unhandled);
-  SET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
-  default: FENIX_THROW(FENIX_ERROR_INTERN);
+    SET_OPTION_CASE(RECOVERY, recovery);
+    SET_OPTION_CASE(RESUME, resume);
+    SET_OPTION_CASE(UNHANDLED, unhandled);
+    SET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
+  default:
+    FENIX_THROW(FENIX_ERROR_INTERN);
   }
 }
 
-#define GET_OPTION_CASE(n, v) case n##_MODE: return fenix_rt.settings. v
+#define GET_OPTION_CASE(n, v)                                                  \
+  case n##_MODE:                                                               \
+    return fenix_rt.settings.v
 
 int get_option(SettingName setting) {
   if (!fenix_rt.fenix_init_flag) FENIX_THROW(FENIX_ERROR_UNINITIALIZED);
   switch (setting) {
-  GET_OPTION_CASE(RECOVERY, recovery);
-  GET_OPTION_CASE(RESUME, resume);
-  GET_OPTION_CASE(UNHANDLED, unhandled);
-  GET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
-  default: FENIX_THROW(FENIX_ERROR_INTERN);
+    GET_OPTION_CASE(RECOVERY, recovery);
+    GET_OPTION_CASE(RESUME, resume);
+    GET_OPTION_CASE(UNHANDLED, unhandled);
+    GET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
+  default:
+    FENIX_THROW(FENIX_ERROR_INTERN);
   }
 }
 

--- a/src/fenix.cpp
+++ b/src/fenix.cpp
@@ -68,6 +68,28 @@ const Fenix_Data_subset FENIX_DATA_SUBSET_FULL = {
 const Fenix_Data_subset FENIX_DATA_SUBSET_EMPTY = {new DataSubset()};
 Fenix_Data_subset* FENIX_DATA_SUBSET_IGNORE = NULL;
 
+int Fenix_set_option(Fenix_Setting_name setting, int option) {
+  // This function gets special handling, since it can be called before init
+#ifdef FENIC_C_CATCH_RUNTIME_EXCEPTIONS
+  try {
+    set_option(setting, option);
+    return FENIX_SUCCESS;
+  } catch (const fenix::RuntimeException& e){
+    return e.error;
+  }
+#else
+  set_option(setting, option);
+  return FENIX_SUCCESS;
+#endif
+}
+
+int Fenix_get_option(Fenix_Setting_name setting, int* option) {
+  FENIX_C_API_BEGIN
+  *option = get_option(setting);
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
+}
+
 int Fenix_Callback_register(
   void (*recover)(MPI_Comm, int, void*), void* callback_data
 ) {
@@ -107,7 +129,7 @@ int Fenix_check_cancelled(MPI_Request* request, MPI_Status* status) {
   FENIX_C_API_BEGIN
   // We know this may return as "COMM_REVOKED", but we know the error was
   // already handled
-  util::ScopedIgnoreErrs ignore_errs{true};
+  util::ScopedIgnoreAndReturn opt;
 
   int flag;
   int ret = PMPI_Test(request, &flag, status);
@@ -139,6 +161,41 @@ int Fenix_get_nspare() {
 }
 
 namespace fenix {
+
+#define SET_OPTION_CASE(name, var)                                             \
+  case name##_MODE:                                                            \
+    if (option >= FENIX_##name##_MODE_MAXCODE) {                               \
+      FENIX_THROW(FENIX_ERROR_INVALID_SETTING_OPTION);                         \
+    }                                                                          \
+    if (!fenix_rt.fenix_init_flag) fenix_rt.user_defaults. var = option;       \
+    else fenix_rt.settings. var = option;                                      \
+    break
+
+void set_option(SettingName setting, int option) {
+  if (setting >= FENIX_SETTING_NAME_MAXCODE) {
+    FENIX_THROW(FENIX_ERROR_INVALID_SETTING_NAME);
+  }
+  switch (setting) {
+  SET_OPTION_CASE(RECOVERY, recovery);
+  SET_OPTION_CASE(RESUME, resume);
+  SET_OPTION_CASE(UNHANDLED, unhandled);
+  SET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
+  default: FENIX_THROW(FENIX_ERROR_INTERN);
+  }
+}
+
+#define GET_OPTION_CASE(n, v) case n##_MODE: return fenix_rt.settings. v
+
+int get_option(SettingName setting) {
+  if (!fenix_rt.fenix_init_flag) FENIX_THROW(FENIX_ERROR_UNINITIALIZED);
+  switch (setting) {
+  GET_OPTION_CASE(RECOVERY, recovery);
+  GET_OPTION_CASE(RESUME, resume);
+  GET_OPTION_CASE(UNHANDLED, unhandled);
+  GET_OPTION_CASE(CALLBACK_EXCEPTION, callback_exception);
+  default: FENIX_THROW(FENIX_ERROR_INTERN);
+  }
+}
 
 void throw_exception() {
   assert(initialized());

--- a/src/fenix_callbacks.cpp
+++ b/src/fenix_callbacks.cpp
@@ -94,7 +94,7 @@ int callback_invoke_all(CallbackLocation loc) {
   //within a callback, we want to only finish the most recent call. All prior
   //calls should exit as soon as control returns.
   static int callbacks_depth = 0;
-  int m_callbacks_layer = callbacks_depth++;
+  int m_callbacks_layer      = callbacks_depth++;
 
   try {
     for (auto& cb : callbacks(loc)) {
@@ -102,7 +102,7 @@ int callback_invoke_all(CallbackLocation loc) {
       cb(*fenix_rt.user_world, fenix_rt.mpi_fail_code);
     }
   } catch (const CommException& e) {
-    switch (fenix_rt.settings.callback_exception) {
+    switch (fenix_rt.settings.cb_exception) {
     case (RETHROW):
       if (m_callbacks_layer == 0) callbacks_depth = 0;
       throw;

--- a/src/fenix_callbacks.cpp
+++ b/src/fenix_callbacks.cpp
@@ -102,7 +102,7 @@ int callback_invoke_all(CallbackLocation loc) {
       cb(*fenix_rt.user_world, fenix_rt.mpi_fail_code);
     }
   } catch (const CommException& e) {
-    switch (fenix_rt.callback_exception_mode) {
+    switch (fenix_rt.settings.callback_exception) {
     case (RETHROW):
       if (m_callbacks_layer == 0) callbacks_depth = 0;
       throw;

--- a/src/fenix_opt.cpp
+++ b/src/fenix_opt.cpp
@@ -62,30 +62,25 @@
 
 #define DEBUG 1
 
-
-
-
 /**
  * @brief
  * @param argc
  * @param argv
  * @param opts
  */
-void __fenix_init_opt(int argc, char **argv) {
-   int i;
+void __fenix_init_opt(int argc, char** argv) {
+  int i;
 
-   /* Initialize the value */
+  /* Initialize the value */
 
-   fenix_rt.options.verbose = -1;
+  fenix::fenix_rt.options.verbose = -1;
 
-   for( i = 0; i < argc; i++ )
-   {
-      if( strcmp(argv[i],"--fenix_v") == 0 || strcmp(argv[i],"--FENIX_V") == 0 )
-      {
-         if( i+1 < argc )
-         {
-            fenix_rt.options.verbose = atoi(argv[i+1]);
-         }
+  for (i = 0; i < argc; i++) {
+    if (strcmp(argv[i], "--fenix_v") == 0 ||
+        strcmp(argv[i], "--FENIX_V") == 0) {
+      if (i + 1 < argc) {
+        fenix::fenix_rt.options.verbose = atoi(argv[i + 1]);
       }
     }
+  }
 }

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -66,13 +66,12 @@
 #include "fenix_opt.hpp"
 #include "fenix_util.hpp"
 
-#define APPLY_USER_DEFAULT(setting_name)                                      \
-    do {                                                                      \
-        if (fenix_rt.user_defaults. setting_name != -1) {                    \
-            fenix_rt.settings. setting_name =                                \
-                fenix_rt.user_defaults. setting_name;                        \
-        }                                                                     \
-    } while (false)
+#define APPLY_USER_DEFAULT(setting_name)                                       \
+  do {                                                                         \
+    if (fenix_rt.user_defaults.setting_name != -1) {                           \
+      fenix_rt.settings.setting_name = fenix_rt.user_defaults.setting_name;    \
+    }                                                                          \
+  } while (false)
 
 namespace fenix {
 

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -66,6 +66,13 @@
 #include "fenix_opt.hpp"
 #include "fenix_util.hpp"
 
+#define APPLY_USER_DEFAULT(setting_name)                                      \
+    do {                                                                      \
+        if (fenix_rt.user_defaults. setting_name != -1) {                    \
+            fenix_rt.settings. setting_name =                                \
+                fenix_rt.user_defaults. setting_name;                        \
+        }                                                                     \
+    } while (false)
 
 namespace fenix {
 
@@ -77,6 +84,8 @@ static int __fenix_spare_rank();
 static void __fenix_finalize_spare();
 
 static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr){
+    fenix_rt.finalized = false;
+
     fenix_rt.world = (MPI_Comm *)malloc(sizeof(MPI_Comm));
     MPI_Comm_dup(args.in_comm, fenix_rt.world);
     
@@ -85,16 +94,24 @@ static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr)
 
     fenix_rt.user_world = args.out_comm;
     fenix_rt.spare_ranks = args.spares;
-    fenix_rt.spawn_policy = args.spawn;
     fenix_rt.recover_environment = jump_env;
-    fenix_rt.resume_mode = args.resume_mode;
-    fenix_rt.unhandled_mode = args.unhandled_mode;
-    fenix_rt.callback_exception_mode = args.callback_exception_mode;
+
     fenix_rt.ret_role = args.role ? args.role : &fenix_rt.role;
     fenix_rt.ret_error = args.err ? args.err : &fenix_rt.repair_result;
 
     *fenix_rt.ret_role = fenix_rt.role;
     *fenix_rt.ret_error = FENIX_SUCCESS;
+
+    APPLY_USER_DEFAULT(recovery);
+    APPLY_USER_DEFAULT(callback_exception);
+    APPLY_USER_DEFAULT(unhandled);
+
+    fenix_rt.settings.resume = jump_env ? JUMP : THROW;
+    APPLY_USER_DEFAULT(resume);
+    fenix_assert(
+        fenix_rt.settings.resume != JUMP || jump_env != nullptr,
+        "Must use Fenix_Init to use FENIX_RESUME_JUMP"
+    );
 
     MPI_Op_create((MPI_User_function *) __fenix_ranks_agree, 1, &fenix_rt.agree_op);
 
@@ -117,32 +134,33 @@ static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr)
     while (__fenix_create_new_world());
 
     if ( __fenix_spare_rank() != 1) {
-        fenix_rt.num_inital_ranks = __fenix_get_world_size(fenix_rt.new_world);
+        fenix_rt.num_initial_ranks = __fenix_get_world_size(fenix_rt.new_world);
         if (fenix_rt.options.verbose == 0) {
             verbose_print("rank: %d, role: %d, number_initial_ranks: %d\n",
                           __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role,
-                          fenix_rt.num_inital_ranks);
+                          fenix_rt.num_initial_ranks);
         }
 
     } else {
-        fenix_rt.num_inital_ranks = fenix_rt.spare_ranks;
+        fenix_rt.num_initial_ranks = fenix_rt.spare_ranks;
 
         if (fenix_rt.options.verbose == 0) {
             verbose_print("rank: %d, role: %d, number_initial_ranks: %d\n",
                           __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role,
-                          fenix_rt.num_inital_ranks);
+                          fenix_rt.num_initial_ranks);
         }
     }
 
     fenix_rt.fenix_init_flag = true;
 
     while ( __fenix_spare_rank() == 1) {
-        int a;
+        int a, ret;
         MPI_Status mpi_status;
-        fenix_rt.ignore_errs = true;
-        int ret = PMPI_Recv(&a, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG,
+        {
+            util::ScopedIgnoreAndReturn opts;
+            ret = PMPI_Recv(&a, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG,
                             *fenix_rt.world, &mpi_status);
-        fenix_rt.ignore_errs = false;
+        }
         if (ret == MPI_SUCCESS) {
             if (fenix_rt.options.verbose == 0) {
                 verbose_print("Finalize the program; rank: %d, role: %d\n",
@@ -173,7 +191,6 @@ static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr)
 }
 
 void init(const args::FenixInitArgs args){
-    fenix_assert(args.resume_mode != JUMP, "Must use Fenix_Init to use the JUMP resume mode");
 
     preinit(args);
     __fenix_postinit();
@@ -262,11 +279,13 @@ int __fenix_create_new_world(){
 
 int __fenix_repair_ranks()
 {
+    util::ScopedIgnoreAndReturn scoped_opts;
+    int recovery = scoped_opts.recovery.old;
+    if(recovery == NOOP) return FENIX_SUCCESS;
+
     /*********************************************************/
     /* Do not forget comm_free for broken communicators      */
     /*********************************************************/
-    fenix_rt.ignore_errs = 1;
-
     int ret;
     int survived_flag;
     int *survivor_world;
@@ -338,8 +357,8 @@ int __fenix_repair_ranks()
                     fenix_rt.fail_world_size);
             }
 
-            if (fenix_rt.spawn_policy == 1) {
-                debug_print("Spawn policy <%d>is not supported\n", fenix_rt.spawn_policy);
+            if (recovery == SPAWN) {
+                debug_print("FENIX_RECOVERY_SPAWN is not supported\n");
             } else {
 
                 rt_code = FENIX_WARNING_SPARE_RANKS_DEPLETED;
@@ -394,7 +413,7 @@ int __fenix_repair_ranks()
                     goto END_LOOP;
                 }
 
-                fenix_rt.num_inital_ranks = 0;
+                fenix_rt.num_initial_ranks = 0;
 
                 /* recovered ranks must be the number of spare ranks */
                 fenix_rt.num_recovered_ranks = fenix_rt.fail_world_size;
@@ -486,7 +505,7 @@ int __fenix_repair_ranks()
             }
 
 
-            fenix_rt.num_inital_ranks = 0;
+            fenix_rt.num_initial_ranks = 0;
             fenix_rt.num_recovered_ranks = fenix_rt.fail_world_size;
             
             if(fenix_rt.role != FENIX_ROLE_INITIAL_RANK){
@@ -587,7 +606,6 @@ int __fenix_repair_ranks()
     }
 
     *fenix_rt.world = fixed_world;
-    fenix_rt.ignore_errs=0;
     return rt_code;
 }
 
@@ -617,17 +635,18 @@ int __fenix_spare_rank(){
 
 int detect_failures(bool do_recovery) {
     FENIX_CPP_API_BEGIN
-    if(!fenix_rt.new_world_exists) return FENIX_ERROR_UNINITIALIZED;
+    if(!fenix_rt.new_world_exists) FENIX_THROW(FENIX_ERROR_UNINITIALIZED);
 
-    int old_ignore_errs = fenix_rt.ignore_errs;
-    fenix_rt.ignore_errs = !do_recovery;
+    if (!do_recovery) {
+        util::ScopedIgnoreAndReturn scoped_opts;
+        return detect_failures(true);
+    }
 
     int req_completed;
-    int ret = MPI_Test(&fenix_rt.check_failures_req, &req_completed, MPI_STATUS_IGNORE);
-
-    if(req_completed) ret = FENIX_ERROR_INTERN;
-    
-    fenix_rt.ignore_errs = old_ignore_errs;
+    int ret = MPI_Test(
+        &fenix_rt.check_failures_req, &req_completed, MPI_STATUS_IGNORE
+    );
+    if(req_completed) FENIX_THROW(FENIX_ERROR_INTERN);
     return ret;
     FENIX_CPP_API_END
 }
@@ -676,59 +695,61 @@ void __fenix_finalize_spare()
     exit(0);
 }
 
-void __fenix_test_MPI(MPI_Comm *pcomm, int *pret, ...)
-{
-    int ret_repair;
-    int index;
+void handle_mpi_error(MPI_Comm* pcomm, int* pret){
     fenix_rt.mpi_fail_code = *pret;
-    if(!fenix_rt.fenix_init_flag || __fenix_spare_rank() == 1 || fenix_rt.ignore_errs) {
-        return;
-    }
 
     switch (fenix_rt.mpi_fail_code) {
-        case MPI_ERR_PROC_FAILED_PENDING:
-        case MPI_ERR_PROC_FAILED:
-            callback_invoke_all(fenix::PRE_RECOVERY);
-            MPIX_Comm_revoke(*fenix_rt.world);
-            MPIX_Comm_revoke(fenix_rt.new_world);
-            if(fenix_rt.user_world_exists) MPIX_Comm_revoke(*fenix_rt.user_world);
+    case MPI_ERR_PROC_FAILED_PENDING:
+    case MPI_ERR_PROC_FAILED:
+        callback_invoke_all(fenix::PRE_RECOVERY);
+        MPIX_Comm_revoke(*fenix_rt.world);
+        MPIX_Comm_revoke(fenix_rt.new_world);
+        if(fenix_rt.user_world_exists) MPIX_Comm_revoke(*fenix_rt.user_world);
 
-            fenix_rt.repair_result = __fenix_repair_ranks();
-            break;
-        case MPI_ERR_REVOKED:
-            callback_invoke_all(fenix::PRE_RECOVERY);
-            fenix_rt.repair_result = __fenix_repair_ranks();
-            break;
-        default:
-            int len;
-            char errstr[MPI_MAX_ERROR_STRING];
-            MPI_Error_string(fenix_rt.mpi_fail_code, errstr, &len);
-            switch (fenix_rt.unhandled_mode) {
-                case ABORT:
-                    fprintf(stderr, "UNHANDLED ERR: %s\n", errstr);
-                    MPI_Abort(*fenix_rt.world, 1);
-                    break;
-                case PRINT:
-                    fprintf(stderr, "UNHANDLED ERR: %s\n", errstr);
-                    break;
-                case SILENT:
-                    break;
-                default:
-                    printf(
-                        "Fenix internal error: Unknown unhandled mode %d\n",
-                        fenix_rt.unhandled_mode
-                    );
-                    assert(false);
-                    break;
-            }
-            return;
-            break;
+        fenix_rt.repair_result = __fenix_repair_ranks();
+        break;
+    case MPI_ERR_REVOKED:
+        callback_invoke_all(fenix::PRE_RECOVERY);
+        fenix_rt.repair_result = __fenix_repair_ranks();
+        break;
+    default:
+        int len;
+        char errstr[MPI_MAX_ERROR_STRING];
+        MPI_Error_string(fenix_rt.mpi_fail_code, errstr, &len);
+        switch (fenix_rt.settings.unhandled) {
+            case ABORT:
+                fprintf(stderr, "UNHANDLED ERR: %s\n", errstr);
+                MPI_Abort(*fenix_rt.world, 1);
+                break;
+            case PRINT:
+                fprintf(stderr, "UNHANDLED ERR: %s\n", errstr);
+                break;
+            case SILENT:
+                break;
+            default:
+                printf(
+                    "Fenix internal error: Unknown unhandled mode %d\n",
+                    fenix_rt.settings.unhandled
+                );
+                assert(false);
+                break;
+        }
+        return;
+        break;
     }
 
     fenix_rt.role = FENIX_ROLE_SURVIVOR_RANK;
     __fenix_postinit();
+}
+
+void __fenix_test_MPI(MPI_Comm *pcomm, int *pret, ...)
+{
+    if(!fenix_rt.fenix_init_flag || __fenix_spare_rank() == 1) return;
+
+    if(fenix_rt.settings.recovery != IGNORE) handle_mpi_error(pcomm, pret);
+
     if(!fenix_rt.finalized) {
-        switch(fenix_rt.resume_mode) {
+        switch(fenix_rt.settings.resume) {
             case JUMP:
                 longjmp(*fenix_rt.recover_environment, 1);
                 break;
@@ -739,7 +760,7 @@ void __fenix_test_MPI(MPI_Comm *pcomm, int *pret, ...)
                 break;
             default:
                 printf("Fenix internal error: Unknown resume mode %d\n",
-                       fenix_rt.resume_mode);
+                       fenix_rt.settings.resume);
                 assert(false);
                 break;
         }
@@ -752,7 +773,7 @@ using namespace fenix;
 
 int __fenix_preinit(
     int *role, MPI_Comm comm, MPI_Comm *new_comm, int *argc, char ***argv,
-    int spare_ranks, int spawn, MPI_Info info, int *error, jmp_buf *jump_env
+    int spare_ranks, int *error, jmp_buf *jump_env
 ) {
     args::FenixInitArgs args;
     args.role = role;
@@ -761,22 +782,7 @@ int __fenix_preinit(
     args.argc = argc;
     args.argv = argv;
     args.spares = spare_ranks;
-    args.spawn = spawn;
     args.err = error;
-    if(info != MPI_INFO_NULL){
-        char value[MPI_MAX_INFO_VAL + 1];
-        int vallen = MPI_MAX_INFO_VAL;
-        int found;
-
-        MPI_Info_get(info, "FENIX_RESUME_MODE", vallen, value, &found);
-        if(found) args.resume_mode = get_resume_mode(value);
-        else args.resume_mode = JUMP;
-
-        MPI_Info_get(info, "FENIX_UNHANDLED_MODE", vallen, value, &found);
-        if(found) args.unhandled_mode = get_unhandled_mode(value);
-    } else {
-        args.resume_mode = JUMP;
-    }
     return preinit(args, jump_env);
 }
 
@@ -818,7 +824,8 @@ int Fenix_Finalize() {
     int last_spare_rank = __fenix_get_world_size(*fenix_rt.world) - 1;
 
     //If we've reached here, we will finalized regardless of further errors.
-    fenix_rt.ignore_errs = true;
+    fenix_rt.settings.recovery = IGNORE;
+    fenix_rt.settings.resume = RETURN;
     while(!fenix_rt.finalized){
         int user_rank = __fenix_get_current_rank(*fenix_rt.user_world);
 
@@ -868,6 +875,7 @@ int Fenix_Finalize() {
 
     /* Free up any C++ data structures, reset default variables */
     fenix_rt = {};
+    fenix_rt.finalized = true;
     return FENIX_SUCCESS;
     FENIX_C_API_END
 }

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -66,13 +66,6 @@
 #include "fenix_opt.hpp"
 #include "fenix_util.hpp"
 
-#define APPLY_USER_DEFAULT(setting_name)                                       \
-  do {                                                                         \
-    if (fenix_rt.user_defaults.setting_name != -1) {                           \
-      fenix_rt.settings.setting_name = fenix_rt.user_defaults.setting_name;    \
-    }                                                                          \
-  } while (false)
-
 namespace fenix {
 
 static int __fenix_create_new_world();
@@ -101,12 +94,10 @@ static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr)
     *fenix_rt.ret_role = fenix_rt.role;
     *fenix_rt.ret_error = FENIX_SUCCESS;
 
-    APPLY_USER_DEFAULT(recovery);
-    APPLY_USER_DEFAULT(callback_exception);
-    APPLY_USER_DEFAULT(unhandled);
-
-    fenix_rt.settings.resume = jump_env ? JUMP : THROW;
-    APPLY_USER_DEFAULT(resume);
+    fenix_rt.settings = fenix_default_settings;
+    if (fenix_rt.settings.resume == FENIX_RESUME_MODE_MAXCODE) {
+        fenix_rt.settings.resume = jump_env ? JUMP : THROW;
+    }
     fenix_assert(
         fenix_rt.settings.resume != JUMP || jump_env != nullptr,
         "Must use Fenix_Init to use FENIX_RESUME_JUMP"

--- a/test/exception_throw/fenix_exceptions.cpp
+++ b/test/exception_throw/fenix_exceptions.cpp
@@ -70,10 +70,8 @@ int main(int argc, char **argv) {
 
   int fenix_role, error;
   MPI_Comm res_comm;
-  MPI_Info info;
-  MPI_Info_create(&info);
-  MPI_Info_set(info, "FENIX_RESUME_MODE", "THROW");
-  Fenix_Init(&fenix_role, MPI_COMM_WORLD, &res_comm, &argc, &argv, 0, 0, info, &error);
+  Fenix_Init(&fenix_role, MPI_COMM_WORLD, &res_comm, &argc, &argv, 0, &error);
+  Fenix_set_option(FENIX_RESUME_MODE, FENIX_RESUME_THROW);
 
   if(fenix_role == FENIX_ROLE_SURVIVOR_RANK){
     printf("FAILURE: longjmp instead of exception\n");

--- a/test/failed_spares/fenix_failed_spares.c
+++ b/test/failed_spares/fenix_failed_spares.c
@@ -106,8 +106,7 @@ int main(int argc, char** argv) {
   MPI_Comm new_comm;
   int error;
   Fenix_Init(
-    &fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, 0,
-    MPI_INFO_NULL, &error
+    &fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, &error
   );
 
   if (fenix_status != FENIX_ROLE_INITIAL_RANK) {

--- a/test/issend/fenix_issend_test.c
+++ b/test/issend/fenix_issend_test.c
@@ -85,15 +85,13 @@ int main(int argc, char **argv) {
   MPI_Comm_size(world_comm, &old_world_size);
   MPI_Comm_rank(world_comm, &old_rank);
 
-  MPI_Info info;
-  MPI_Info_create(&info);
-  MPI_Info_set(info, "FENIX_RESUME_MODE", "RETURN");
+  Fenix_set_option(FENIX_RESUME_MODE, FENIX_RESUME_RETURN);
 
   int fenix_status;
   int recovered = 0;
   MPI_Comm new_comm;
   int error;
-  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, 0, info, &error);
+  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, &error);
 
   MPI_Comm_size(new_comm, &new_world_size);
   MPI_Comm_rank(new_comm, &new_rank);

--- a/test/no_jump/fenix_no_jump_test.c
+++ b/test/no_jump/fenix_no_jump_test.c
@@ -85,15 +85,13 @@ int main(int argc, char **argv) {
   MPI_Comm_size(world_comm, &old_world_size);
   MPI_Comm_rank(world_comm, &old_rank);
 
-  MPI_Info info;
-  MPI_Info_create(&info);
-  MPI_Info_set(info, "FENIX_RESUME_MODE", "RETURN");
+  Fenix_set_option(FENIX_RESUME_MODE, FENIX_RESUME_RETURN);
 
   int fenix_status;
   int recovered = 0;
   MPI_Comm new_comm;
   int error;
-  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, 0, info, &error);
+  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, &error);
 
   MPI_Comm_size(new_comm, &new_world_size);
   MPI_Comm_rank(new_comm, &new_rank);

--- a/test/request_cancelled/fenix_req_cancelled_test.c
+++ b/test/request_cancelled/fenix_req_cancelled_test.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
   int error;
   MPI_Request req = MPI_REQUEST_NULL;
   fprintf(stderr, "Before Fenix init\n");
-  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, 0, MPI_INFO_NULL, &error);
+  Fenix_Init(&fenix_status, world_comm, &new_comm, &argc, &argv, spare_ranks, &error);
   fprintf(stderr, "After Fenix init\n");
     
   MPI_Comm_size(new_comm, &new_world_size);

--- a/test/request_tracking/fenix_request_tracking_test.c
+++ b/test/request_tracking/fenix_request_tracking_test.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
     int fenix_status;
     int error;
     int spare_ranks = 1;
-    Fenix_Init(&fenix_status, MPI_COMM_WORLD, &newcomm, &argc, &argv, spare_ranks, 0, MPI_INFO_NULL, &error);
+    Fenix_Init(&fenix_status, MPI_COMM_WORLD, &newcomm, &argc, &argv, spare_ranks, &error);
 #else
     #warning "no fenix"
     MPI_Comm_dup(MPI_COMM_WORLD, &newcomm);


### PR DESCRIPTION
Expose Fenix's global settings via `Fenix_set_option` and `Fenix_get_option`.

Merges existing variables `spawn_policy` and `ignore_errs` into the FENIX_RECOVERY_MODE setting.

Removes the MPI_Info parameter for Fenix_Init - instead users can set options before or after initializing with `Fenix_set_option`.

This is a QoL adjustment for now, but is intended to support more settings for the message logging work and some more future extensions to the Fenix API.