### PR TITLE
Add SpareWaitMode config

### DIFF
--- a/include/fenix.h
+++ b/include/fenix.h
@@ -180,6 +180,8 @@ typedef enum {
     FENIX_CALLBACK_EXCEPTION_MODE,
     //!See #Fenix_Mlog_recovery_mode
     FENIX_MLOG_RECOVERY_MODE,
+    //!See #Fenix_Spare_wait_mode
+    FENIX_SPARE_WAIT_MODE,
 
     //!Not a valid option.
     FENIX_SETTING_NAME_MAXCODE
@@ -268,6 +270,22 @@ typedef enum {
     //!Not a valid option
     FENIX_UNHANDLED_MODE_MAXCODE
 } Fenix_Unhandled_mode;
+
+/**
+ * @brief Options for how spare ranks wait to be needed. Must be set before
+ * Fenix_Init to take effect.
+ */
+typedef enum {
+    //!Busy wait, consuming CPU time in exchange for faster response
+    FENIX_SPARE_WAIT_BUSY,
+    //!Tell MPI to yield this thread while waiting (if supported, else busy wait)
+    FENIX_SPARE_WAIT_YIELD,
+    //!Sleep 100ms between checks to see if this thread is needed for recovery
+    FENIX_SPARE_WAIT_SLEEP,
+
+    //!Not a valid option
+    FENIX_SPARE_WAIT_MODE_MAXCODE
+} Fenix_Spare_wait_mode;
 
 /**
  * @brief Options for dealing with CommExceptions generated in callbacks

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -78,6 +78,7 @@ constexpr SettingName RESUME_MODE             = FENIX_RESUME_MODE;
 constexpr SettingName UNHANDLED_MODE          = FENIX_UNHANDLED_MODE;
 constexpr SettingName CALLBACK_EXCEPTION_MODE = FENIX_CALLBACK_EXCEPTION_MODE;
 constexpr SettingName MLOG_RECOVERY_MODE      = FENIX_MLOG_RECOVERY_MODE;
+constexpr SettingName SPARE_WAIT_MODE         = FENIX_SPARE_WAIT_MODE;
 
 using RecoveryMode            = Fenix_Recovery_mode;
 constexpr RecoveryMode IGNORE = FENIX_RECOVERY_IGNORE;
@@ -104,6 +105,11 @@ constexpr MlogRecoveryMode MANUAL = FENIX_MLOG_RECOVERY_MANUAL;
 constexpr MlogRecoveryMode INLINE = FENIX_MLOG_RECOVERY_INLINE;
 constexpr MlogRecoveryMode INLINE_AUTOSYNC =
   FENIX_MLOG_RECOVERY_INLINE_AUTOSYNC;
+
+using SpareWaitMode           = Fenix_Spare_wait_mode;
+constexpr SpareWaitMode BUSY  = FENIX_SPARE_WAIT_BUSY;
+constexpr SpareWaitMode YIELD = FENIX_SPARE_WAIT_YIELD;
+constexpr SpareWaitMode SLEEP = FENIX_SPARE_WAIT_SLEEP;
 
 constexpr int STOREV_ALL = FENIX_STOREV_ALL;
 

--- a/include/fenix_ext.hpp
+++ b/include/fenix_ext.hpp
@@ -77,6 +77,7 @@ struct Settings {
   CallbackExceptionMode cb_exception = SQUASH;
   UnhandledMode unhandled            = ABORT;
   MlogRecoveryMode mlog_recovery     = MANUAL;
+  SpareWaitMode spare_wait           = YIELD;
 };
 
 // Configurations before init change this

--- a/src/fenix.cpp
+++ b/src/fenix.cpp
@@ -197,6 +197,7 @@ void set_option(SettingName setting, unsigned option) {
     SET_OPTION_CASE(UNHANDLED, unhandled);
     SET_OPTION_CASE(CALLBACK_EXCEPTION, cb_exception);
     SET_OPTION_CASE(MLOG_RECOVERY, mlog_recovery);
+    SET_OPTION_CASE(SPARE_WAIT, spare_wait);
   default:
     FENIX_THROW(FENIX_ERROR_INTERN);
   }
@@ -214,6 +215,7 @@ unsigned get_option(SettingName setting) {
     GET_OPTION_CASE(UNHANDLED, unhandled);
     GET_OPTION_CASE(CALLBACK_EXCEPTION, cb_exception);
     GET_OPTION_CASE(MLOG_RECOVERY, mlog_recovery);
+    GET_OPTION_CASE(SPARE_WAIT, spare_wait);
   default:
     FENIX_THROW(FENIX_ERROR_INTERN);
   }

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -226,6 +226,13 @@ void spare_rank_loop() {
                     MPI_ANY_SOURCE, MPI_ANY_TAG, *fenix_rt.world, &msg_found,
                     &mpi_status
                 );
+                if (ret == MPI_SUCCESS) {
+                    // Explicit check so older Open MPI versions still work
+                    int is_revoked;
+                    MPIX_Comm_is_revoked(*fenix_rt.world, &is_revoked);
+                    if (is_revoked) ret = MPI_ERR_REVOKED;
+                }
+
                 if (msg_found || ret != MPI_SUCCESS) break;
                 if (++progress_count >= 5) {
                     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -56,6 +56,8 @@
 
 #include <assert.h>
 #include <sys/time.h>
+#include <chrono>
+#include <thread>
 
 #include <mpi.h>
 #ifndef MPICH_VERSION
@@ -73,6 +75,7 @@ static int __fenix_repair_ranks();
 static void __fenix_test_MPI(MPI_Comm*, int*, ...);
 static int* __fenix_get_fail_ranks(int *, int, int);
 static int __fenix_spare_rank();
+static void spare_rank_loop();
 static void __fenix_finalize_spare();
 
 static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr){
@@ -143,36 +146,7 @@ static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr)
 
     fenix_rt.fenix_init_flag = true;
 
-    while ( __fenix_spare_rank() == 1) {
-        int a, ret;
-        MPI_Status mpi_status;
-        {
-            util::ScopedIgnoreAndReturn opts;
-            ret = PMPI_Recv(&a, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG,
-                            *fenix_rt.world, &mpi_status);
-        }
-        if (ret == MPI_SUCCESS) {
-            if (fenix_rt.options.verbose == 0) {
-                verbose_print("Finalize the program; rank: %d, role: %d\n",
-                              __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role);
-            }
-            __fenix_finalize_spare();
-        } else if(ret == MPI_ERR_REVOKED){
-            fenix_rt.repair_result = __fenix_repair_ranks();
-            if (fenix_rt.options.verbose == 0) {
-                verbose_print("spare rank exiting from MPI_Recv - repair ranks; rank: %d, role: %d\n",
-                              __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role);
-            }
-        } else {
-#ifdef MPICH_VERSION
-            MPIX_Comm_failure_ack(*fenix_rt.world);
-#else
-            MPIX_Comm_ack_failed(*fenix_rt.world, __fenix_get_world_size(*fenix_rt.world), &a);
-#endif
-        }
-        fenix_rt.role = FENIX_ROLE_RECOVERED_RANK;
-    }
-
+    if(__fenix_spare_rank() == 1) spare_rank_loop();
     
     if(fenix_rt.role != FENIX_ROLE_RECOVERED_RANK) MPI_Comm_dup(fenix_rt.new_world, fenix_rt.user_world);
     fenix_rt.user_world_exists = true;
@@ -220,6 +194,74 @@ int __fenix_spare_rank_within(MPI_Comm refcomm)
         result = 1;
     }
     return result;
+}
+
+void spare_rank_loop() {
+    const bool yield_mode = get_option(SPARE_WAIT_MODE) == YIELD;
+    const bool sleep_mode = get_option(SPARE_WAIT_MODE) == SLEEP;
+
+    int provided_thread_level;
+    MPI_T_init_thread(MPI_THREAD_SINGLE, &provided_thread_level);
+
+    MPI_T_cvar_handle yield_cvar = MPI_T_CVAR_HANDLE_NULL;
+    bool old_yield_setting = false;
+    if (yield_mode) {
+        int idx, count;
+        int ret = MPI_T_cvar_get_index("mpi_yield_when_idle", &idx);
+        if (ret == MPI_SUCCESS) {
+            MPI_T_cvar_handle_alloc(idx, NULL, &yield_cvar, &count);
+            MPI_T_cvar_read(yield_cvar, &old_yield_setting);
+            MPI_T_cvar_write(yield_cvar, &yield_mode);
+        }
+    }
+
+    while (__fenix_spare_rank() == 1) {
+        int a, ret = MPI_SUCCESS, msg_found = true;
+        MPI_Status mpi_status;
+        {
+            util::ScopedIgnoreAndReturn opts;
+            int progress_count = 0;
+            while (sleep_mode) {
+                ret = PMPI_Iprobe(
+                    MPI_ANY_SOURCE, MPI_ANY_TAG, *fenix_rt.world, &msg_found,
+                    &mpi_status
+                );
+                if (msg_found || ret != MPI_SUCCESS) break;
+                if (++progress_count >= 5) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    progress_count = 0;
+                }
+            }
+            if (ret == MPI_SUCCESS) {
+                ret = PMPI_Recv(
+                    &a, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG,
+                    *fenix_rt.world, &mpi_status
+                );
+            }
+        }
+        if (ret == MPI_SUCCESS) {
+            __fenix_finalize_spare();
+        } else if (ret == MPI_ERR_REVOKED) {
+            fenix_rt.repair_result = __fenix_repair_ranks();
+        } else {
+#ifdef MPICH_VERSION
+            MPIX_Comm_failure_ack(*fenix_rt.world);
+#else
+            MPIX_Comm_ack_failed(
+                *fenix_rt.world, __fenix_get_world_size(*fenix_rt.world), &a
+            );
+#endif
+        }
+    }
+
+    // Cleanup before exiting as a recovered rank
+    if (yield_cvar != MPI_T_CVAR_HANDLE_NULL) {
+        MPI_T_cvar_write(yield_cvar, &old_yield_setting);
+        MPI_T_cvar_handle_free(&yield_cvar);
+    }
+    MPI_T_finalize();
+
+    fenix_rt.role = FENIX_ROLE_RECOVERED_RANK;
 }
 
 int __fenix_create_new_world_from(MPI_Comm from_comm)


### PR DESCRIPTION
This feature allows spare ranks to avoid consuming full CPU time with busy waiting. The default mode is YIELD, which attempts to set an MPI cvar (if available with the MPI implementation) to tell MPI to yield the thread when idly waiting for a message. A more aggressive mode is SLEEP, which does a 100ms sleep between MPI_Iprobe checks - this will have even less resource utilization, but will also have a slight impact on recovery time.

~The sleep method relies on error detection/reporting during MPI_Iprobe, which was only recently correctly supported in Open MPI, so a fairly recent Open MPI will be necessary for proper support.~ (fixed with second commit)

The MPI cvar for yielding will be added to Open MPI here: https://github.com/open-mpi/ompi/pull/13959