### PR TITLE
Linting and minor cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,3 +50,7 @@ BreakTemplateDeclarations: Leave
 
 # Ignore whitespace "issues" in sendrecvs
 WhitespaceSensitiveMacros: [MPI_Sendrecv, MPI_Isendrecv, sendrecv]
+
+# Multiline operands (+, -, &&, etc.) are not indented to align with the equal
+# sign
+AlignOperands: DontAlign

--- a/examples/02_send_recv/fenix/fenix_ring.c
+++ b/examples/02_send_recv/fenix/fenix_ring.c
@@ -158,9 +158,12 @@ int main(int argc, char **argv) {
   } else {
     int out_flag = 0;
     
-    Fenix_Data_member_restore(my_group, 777, outmsg, kCount, 2, NULL);
-    Fenix_Data_member_restore(my_group, 778, x, 4, 1, NULL);
-    Fenix_Data_member_restore(my_group, 779, inmsg, kCount, 1, NULL);
+    Fenix_Data_member_restore(my_group, 777, outmsg, kCount,
+        FENIX_DATA_SNAPSHOT_LATEST, FENIX_DATA_SUBSET_IGNORE);
+    Fenix_Data_member_restore(my_group, 778, x, 4,
+        FENIX_DATA_SNAPSHOT_LATEST, FENIX_DATA_SUBSET_IGNORE);
+    Fenix_Data_member_restore(my_group, 779, inmsg, kCount,
+        FENIX_DATA_SNAPSHOT_LATEST, FENIX_DATA_SUBSET_IGNORE);
     fprintf(stderr, "Did restore on node %d\n", rank);
     
     Fenix_Data_member_attr_set(my_group, 777, FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER,

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -66,8 +66,8 @@
 #define MPI_ERR_PROC_FAILED MPIX_ERR_PROC_FAILED
 #endif
 
-#if defined(MPIX_ERR_PROC_FAILED_PENDING) && \
-    !defined(MPI_ERR_PROC_FAILED_PENDING)
+#if defined(MPIX_ERR_PROC_FAILED_PENDING) &&                                   \
+  !defined(MPI_ERR_PROC_FAILED_PENDING)
 #define MPI_ERR_PROC_FAILED_PENDING MPIX_ERR_PROC_FAILED_PENDING
 #endif
 
@@ -92,51 +92,53 @@ extern "C" {
  * @{
  */
 typedef enum {
-    FENIX_SUCCESS = 0,
-    // Error values are negative
-    FENIX_ERROR_UNINITIALIZED = -100,
-    FENIX_ERROR_NOCATEGORY,
-    FENIX_ERROR_CALLBACK_NOT_REGISTERED,
-    FENIX_ERROR_GROUP_CREATE,
-    FENIX_ERROR_MEMBER_CREATE,
-    FENIX_ERROR_MEMBER_EXISTS,
-    FENIX_ERROR_COMMIT_BARRIER,
-    FENIX_ERROR_INVALID_GROUPID,
-    FENIX_ERROR_INVALID_MEMBERID,
-    FENIX_ERROR_INVALID_LOGIC_CALL,
-    FENIX_ERROR_INVALID_POLICY_NAME,
-    FENIX_ERROR_INVALID_TIMESTAMP,
-    FENIX_ERROR_INVALID_TIMESTART,
-    FENIX_ERROR_INVALID_DEPTH,
-    FENIX_ERROR_INVALID_ATTRIBUTE_NAME,
-    FENIX_ERROR_INVALID_ATTRIBUTE_VALUE,
-    FENIX_ERROR_INVALID_POSITION,
-    FENIX_ERROR_DATA_WAIT,
-    FENIX_ERROR_SUBSET_NUM_BLOCKS,
-    FENIX_ERROR_SUBSET_START_OFFSET,
-    FENIX_ERROR_SUBSET_END_OFFSET,
-    FENIX_ERROR_SUBSET_STRIDE,
-    FENIX_ERROR_NODATA_FOUND,
-    FENIX_ERROR_INTERN,
-    FENIX_ERROR_CANCELLED,
-    FENIX_ERROR_INVALID_SETTING_NAME,
-    FENIX_ERROR_INVALID_SETTING_OPTION,
-    FENIX_ERROR_INVALID_MLOGID,
-    FENIX_ERROR_MLOG_EXISTS,
-    FENIX_ERROR_MLOG_LIBRARY_UNAVAILABLE,
-    FENIX_ERROR_PROCESS_FAILURE,
-    //Warnings are positive
-    FENIX_WARNING_SPARE_RANKS_DEPLETED = 100,
-    FENIX_WARNING_PARTIAL_RESTORE,
+  FENIX_SUCCESS = 0,
+
+  // Error values are negative
+  FENIX_ERROR_UNINITIALIZED = -100,
+  FENIX_ERROR_NOCATEGORY,
+  FENIX_ERROR_CALLBACK_NOT_REGISTERED,
+  FENIX_ERROR_GROUP_CREATE,
+  FENIX_ERROR_MEMBER_CREATE,
+  FENIX_ERROR_MEMBER_EXISTS,
+  FENIX_ERROR_COMMIT_BARRIER,
+  FENIX_ERROR_INVALID_GROUPID,
+  FENIX_ERROR_INVALID_MEMBERID,
+  FENIX_ERROR_INVALID_LOGIC_CALL,
+  FENIX_ERROR_INVALID_POLICY_NAME,
+  FENIX_ERROR_INVALID_TIMESTAMP,
+  FENIX_ERROR_INVALID_TIMESTART,
+  FENIX_ERROR_INVALID_DEPTH,
+  FENIX_ERROR_INVALID_ATTRIBUTE_NAME,
+  FENIX_ERROR_INVALID_ATTRIBUTE_VALUE,
+  FENIX_ERROR_INVALID_POSITION,
+  FENIX_ERROR_DATA_WAIT,
+  FENIX_ERROR_SUBSET_NUM_BLOCKS,
+  FENIX_ERROR_SUBSET_START_OFFSET,
+  FENIX_ERROR_SUBSET_END_OFFSET,
+  FENIX_ERROR_SUBSET_STRIDE,
+  FENIX_ERROR_NODATA_FOUND,
+  FENIX_ERROR_INTERN,
+  FENIX_ERROR_CANCELLED,
+  FENIX_ERROR_INVALID_SETTING_NAME,
+  FENIX_ERROR_INVALID_SETTING_OPTION,
+  FENIX_ERROR_INVALID_MLOGID,
+  FENIX_ERROR_MLOG_EXISTS,
+  FENIX_ERROR_MLOG_LIBRARY_UNAVAILABLE,
+  FENIX_ERROR_PROCESS_FAILURE,
+
+  //Warnings are positive
+  FENIX_WARNING_SPARE_RANKS_DEPLETED = 100,
+  FENIX_WARNING_PARTIAL_RESTORE,
 } Fenix_Return_codes;
 /**@}*/
 
 //!@internal @brief Agreement code for error handler
-#define FENIX_ERRHANDLER_LOC		      1
+#define FENIX_ERRHANDLER_LOC 1
 //!@internal @brief Agreement code for finalizet
-#define FENIX_FINALIZE_LOC		      2
+#define FENIX_FINALIZE_LOC 2
 //!@internal @brief Agreement code for data commit barrier
-#define FENIX_DATA_COMMIT_BARRIER_LOC	      4
+#define FENIX_DATA_COMMIT_BARRIER_LOC 4
 
 /**
  * @defgroup ProcessRecovery Process Recovery
@@ -147,7 +149,7 @@ typedef enum {
 
 /**
  * @brief All possible roles returned by Fenix_Init
- * 
+ *
  * Describes the current process's state in reference
  * to process recovery.
  *
@@ -158,117 +160,117 @@ typedef enum {
  * failure recovery process.
  */
 typedef enum {
-    //!No failures have occurred yet
-    FENIX_ROLE_INITIAL_RANK = 0,
-    //!This rank was a spare before the most recent failure, or was just spawned
-    FENIX_ROLE_RECOVERED_RANK = 1,
-    //!This rank was not a spare before the most recent failure
-    FENIX_ROLE_SURVIVOR_RANK = 2
+  //!No failures have occurred yet
+  FENIX_ROLE_INITIAL_RANK   = 0,
+  //!This rank was a spare before the most recent failure, or was just spawned
+  FENIX_ROLE_RECOVERED_RANK = 1,
+  //!This rank was not a spare before the most recent failure
+  FENIX_ROLE_SURVIVOR_RANK  = 2
 } Fenix_Rank_role;
 
 /**
  * @brief Global Fenix settings.
  */
 typedef enum {
-    //!See #Fenix_Recovery_mode
-    FENIX_RECOVERY_MODE,
-    //!See #Fenix_Resume_mode
-    FENIX_RESUME_MODE,
-    //!See #Fenix_Unhandled_mode
-    FENIX_UNHANDLED_MODE,
-    //!See #Fenix_Callback_exception_mode
-    FENIX_CALLBACK_EXCEPTION_MODE,
-    //!See #Fenix_Mlog_recovery_mode
-    FENIX_MLOG_RECOVERY_MODE,
-    //!See #Fenix_Spare_wait_mode
-    FENIX_SPARE_WAIT_MODE,
+  //!See #Fenix_Recovery_mode
+  FENIX_RECOVERY_MODE,
+  //!See #Fenix_Resume_mode
+  FENIX_RESUME_MODE,
+  //!See #Fenix_Unhandled_mode
+  FENIX_UNHANDLED_MODE,
+  //!See #Fenix_Callback_exception_mode
+  FENIX_CALLBACK_EXCEPTION_MODE,
+  //!See #Fenix_Mlog_recovery_mode
+  FENIX_MLOG_RECOVERY_MODE,
+  //!See #Fenix_Spare_wait_mode
+  FENIX_SPARE_WAIT_MODE,
 
-    //!Not a valid option.
-    FENIX_SETTING_NAME_MAXCODE
+  //!Not a valid option.
+  FENIX_SETTING_NAME_MAXCODE
 } Fenix_Setting_name;
 
 /**
  * @brief Options for recovering after a failed rank is detected
  */
 typedef enum {
-    //!Do not repair communicator, immediately resume per #FENIX_RESUME_MODE
-    FENIX_RECOVERY_IGNORE,
-    /**
-     * @brief Do not repair communicator, otherwise behave normally
-     *
-     * This includes calling the PRE_RECOVERY and POST_RECOVERY callbacks
-     */
-    FENIX_RECOVERY_NOOP,
-    //!Repair the communicator with spares or by shrinking
-    FENIX_RECOVERY_REPAIR,
-    //!@unimplemented As REPAIR, but attempt to respawn failed processes
-    FENIX_RECOVERY_SPAWN,
+  //!Do not repair communicator, immediately resume per #FENIX_RESUME_MODE
+  FENIX_RECOVERY_IGNORE,
+  /**
+   * @brief Do not repair communicator, otherwise behave normally
+   *
+   * This includes calling the PRE_RECOVERY and POST_RECOVERY callbacks
+   */
+  FENIX_RECOVERY_NOOP,
+  //!Repair the communicator with spares or by shrinking
+  FENIX_RECOVERY_REPAIR,
+  //!@unimplemented As REPAIR, but attempt to respawn failed processes
+  FENIX_RECOVERY_SPAWN,
 
-    //!Not a valid option
-    FENIX_RECOVERY_MODE_MAXCODE
+  //!Not a valid option
+  FENIX_RECOVERY_MODE_MAXCODE
 } Fenix_Recovery_mode;
 
 typedef enum {
-    //!All message logging recovery is manual
-    FENIX_MLOG_RECOVERY_MANUAL,
-    /**
-     * @brief Automatically repeats failed, logged MPI operations without
-     *        disrupting normal application control flow.
-     * 
-     * User is responsible for handling any recovery steps in Fenix callbacks.
-     */
-    FENIX_MLOG_RECOVERY_INLINE,
-    /**
-     * @brief As INLINE, but automatically sync logs with FENIX_MLOG_CONTINUE.
-     * 
-     * Invoked after post-recovery callbacks, immediately before resuming.
-     * Invoked regardless of the logged-or-not status of the failing message.
-     */
-    FENIX_MLOG_RECOVERY_INLINE_AUTOSYNC,
+  //!All message logging recovery is manual
+  FENIX_MLOG_RECOVERY_MANUAL,
+  /**
+   * @brief Automatically repeats failed, logged MPI operations without
+   *        disrupting normal application control flow.
+   *
+   * User is responsible for handling any recovery steps in Fenix callbacks.
+   */
+  FENIX_MLOG_RECOVERY_INLINE,
+  /**
+   * @brief As INLINE, but automatically sync logs with FENIX_MLOG_CONTINUE.
+   *
+   * Invoked after post-recovery callbacks, immediately before resuming.
+   * Invoked regardless of the logged-or-not status of the failing message.
+   */
+  FENIX_MLOG_RECOVERY_INLINE_AUTOSYNC,
 
-    //!Not a valid option
-    FENIX_MLOG_RECOVERY_MODE_MAXCODE
+  //!Not a valid option
+  FENIX_MLOG_RECOVERY_MODE_MAXCODE
 } Fenix_Mlog_recovery_mode;
 /**
  * @brief Options for passing control back to application after recovery.
  */
 typedef enum {
-    /**
-     * @brief Return to Fenix_Init via longjmp (default)
-     *
-     * The value of variables set before the longjmp are subject to undefined
-     * behavior from compiler optimizations. To ensure expected behavior, it is
-     * recommended that any variables that will be used across the longjmp are
-     * declared as volatile, are heap allocated, or are global in scope.
-     *
-     * For C++ applications, whether stack variables are automatically
-     * destructed when leaving stack frames via longjmp is undefined. For this
-     * reason and the above, it is highly recommended to instead use
-     * #FENIX_RESUME_THROW for C++ applications.
-     */
-    FENIX_RESUME_JUMP,
-    //!Return the error code inline
-    FENIX_RESUME_RETURN,
-    //!Throw a fenix::CommException
-    FENIX_RESUME_THROW,
+  /**
+   * @brief Return to Fenix_Init via longjmp (default)
+   *
+   * The value of variables set before the longjmp are subject to undefined
+   * behavior from compiler optimizations. To ensure expected behavior, it is
+   * recommended that any variables that will be used across the longjmp are
+   * declared as volatile, are heap allocated, or are global in scope.
+   *
+   * For C++ applications, whether stack variables are automatically
+   * destructed when leaving stack frames via longjmp is undefined. For this
+   * reason and the above, it is highly recommended to instead use
+   * #FENIX_RESUME_THROW for C++ applications.
+   */
+  FENIX_RESUME_JUMP,
+  //!Return the error code inline
+  FENIX_RESUME_RETURN,
+  //!Throw a fenix::CommException
+  FENIX_RESUME_THROW,
 
-    //!Not a valid option
-    FENIX_RESUME_MODE_MAXCODE
+  //!Not a valid option
+  FENIX_RESUME_MODE_MAXCODE
 } Fenix_Resume_mode;
 
 /**
  * @brief Options for dealing with 'unhandled' errors, e.g. invalid rank IDs
  */
 typedef enum {
-    //!Ignore unhandled errors
-    FENIX_UNHANDLED_SILENT,
-    //!Print error and continue without handling
-    FENIX_UNHANDLED_PRINT,
-    //!Print error and abort Fenix's world (default)
-    FENIX_UNHANDLED_ABORT,
+  //!Ignore unhandled errors
+  FENIX_UNHANDLED_SILENT,
+  //!Print error and continue without handling
+  FENIX_UNHANDLED_PRINT,
+  //!Print error and abort Fenix's world (default)
+  FENIX_UNHANDLED_ABORT,
 
-    //!Not a valid option
-    FENIX_UNHANDLED_MODE_MAXCODE
+  //!Not a valid option
+  FENIX_UNHANDLED_MODE_MAXCODE
 } Fenix_Unhandled_mode;
 
 /**
@@ -276,28 +278,28 @@ typedef enum {
  * Fenix_Init to take effect.
  */
 typedef enum {
-    //!Busy wait, consuming CPU time in exchange for faster response
-    FENIX_SPARE_WAIT_BUSY,
-    //!Tell MPI to yield this thread while waiting (if supported, else busy wait)
-    FENIX_SPARE_WAIT_YIELD,
-    //!Sleep 100ms between checks to see if this thread is needed for recovery
-    FENIX_SPARE_WAIT_SLEEP,
+  //!Busy wait, consuming CPU time in exchange for faster response
+  FENIX_SPARE_WAIT_BUSY,
+  //!Tell MPI to yield this thread while waiting (if supported, else busy wait)
+  FENIX_SPARE_WAIT_YIELD,
+  //!Sleep 100ms between checks to see if this thread is needed for recovery
+  FENIX_SPARE_WAIT_SLEEP,
 
-    //!Not a valid option
-    FENIX_SPARE_WAIT_MODE_MAXCODE
+  //!Not a valid option
+  FENIX_SPARE_WAIT_MODE_MAXCODE
 } Fenix_Spare_wait_mode;
 
 /**
  * @brief Options for dealing with CommExceptions generated in callbacks
  */
 typedef enum {
-    //!CommExceptions are allowed to propagate out of callbacks
-    FENIX_CALLBACK_EXCEPTION_RETHROW,
-    //!CommExceptions from callbacks are squashed
-    FENIX_CALLBACK_EXCEPTION_SQUASH,
+  //!CommExceptions are allowed to propagate out of callbacks
+  FENIX_CALLBACK_EXCEPTION_RETHROW,
+  //!CommExceptions from callbacks are squashed
+  FENIX_CALLBACK_EXCEPTION_SQUASH,
 
-    //!Not a valid option
-    FENIX_CALLBACK_EXCEPTION_MODE_MAXCODE
+  //!Not a valid option
+  FENIX_CALLBACK_EXCEPTION_MODE_MAXCODE
 } Fenix_Callback_exception_mode;
 
 /**
@@ -364,28 +366,28 @@ typedef enum {
 
 //!@internal
 #define Fenix_Init(_role, _comm, _newcomm, _argc, _argv, _spare_ranks, _err)   \
-    {                                                                          \
-        static jmp_buf bufjmp;                                                 \
-        *(_role) = __fenix_preinit(                                            \
-            _role, _comm, _newcomm, _argc, _argv, _spare_ranks, _err, &bufjmp  \
-        );                                                                     \
-        setjmp(bufjmp);                                                        \
-        __fenix_postinit();                                                    \
-    }
+  {                                                                            \
+    static jmp_buf bufjmp;                                                     \
+    *(_role) = __fenix_preinit(                                                \
+      _role, _comm, _newcomm, _argc, _argv, _spare_ranks, _err, &bufjmp        \
+    );                                                                         \
+    setjmp(bufjmp);                                                            \
+    __fenix_postinit();                                                        \
+  }
 
 /**
  * @brief Sets flag to true if Fenix_Init has been called, else false.
  * @param[out] flag Pointer to the flag to be set.
  * @returnstatus
  */
-int Fenix_Initialized(int *flag);
+int Fenix_Initialized(int* flag);
 
 /**
  * @brief Sets flag to true if Fenix_Finalize has been called, else false.
  * @param[out] flag Pointer to the flag to be set.
  * @returnstatus
  */
-int Fenix_Finalized(int *flag);
+int Fenix_Finalized(int* flag);
 
 /**
  * @brief Configure a global Fenix setting.
@@ -419,17 +421,18 @@ int Fenix_get_option(Fenix_Setting_name setting, unsigned* option);
 /**
  * @brief Register a callback to be invoked after failure process recovery.
  *
- * This function registers a callback to be invoked after a failure has been recovered by Fenix, 
- * and right before resuming application execution (e.g. returning from #Fenix_Init by default).
- * If this function is called more than once, the different callbacks will be called in the 
- * reverse order that they were registered (i.e. as a callback stack).
+ * This function registers a callback to be invoked after a failure has been
+ * recovered by Fenix, and right before resuming application execution (e.g.
+ * returning from #Fenix_Init by default). If this function is called more than
+ * once, the different callbacks will be called in the reverse order that they
+ * were registered (i.e. as a callback stack).
  *
- * Callback functions are passed the newly-repaired resilient communicator, the error code returned
- * by MPI in the communication action which caused a failure recovery, and the user-provided \c void*
- * callback data.
+ * Callback functions are passed the newly-repaired resilient communicator, the
+ * error code returned by MPI in the communication action which caused a failure
+ * recovery, and the user-provided \c void* callback data.
  *
- * Callbacks will only be invoked by survivor ranks, since spare ranks or respawned ranks had no way
- * to register them before a failure.
+ * Callbacks will only be invoked by survivor ranks, since spare ranks or
+ * respawned ranks had no way to register them before a failure.
  *
  * Any active mlog will be deactivated for the duration of callbacks.
  *
@@ -438,8 +441,9 @@ int Fenix_get_option(Fenix_Setting_name setting, unsigned* option);
  *
  * @returnstatus
  */
-int Fenix_Callback_register(void (*recover)(MPI_Comm, int, void *),
-                            void *callback_data);
+int Fenix_Callback_register(
+  void (*recover)(MPI_Comm, int, void*), void* callback_data
+);
 
 /**
  * @brief Pop the most recently registered callback from the callback stack.
@@ -481,10 +485,10 @@ int Fenix_Callback_invoke_all();
 int Fenix_Process_detect_failures(int do_recovery);
 
 //!@unimplemented Returns the number of ranks with a given #Fenix_Rank_role
-int Fenix_get_number_of_ranks_with_role(int, int *);
+int Fenix_get_number_of_ranks_with_role(int, int*);
 
 //!@unimplemented Returns the #Fenix_Rank_role for a given rank
-int Fenix_get_rank_role(MPI_Comm comm, int rank, int *role);
+int Fenix_get_rank_role(MPI_Comm comm, int rank, int* role);
 
 //!@brief Returns this rank's #Fenix_Rank_role
 Fenix_Rank_role Fenix_get_role();
@@ -509,35 +513,38 @@ int Fenix_Process_fail_list(int** fail_list);
  * @return True if the request was cancelled or has unknown completion status,
  *         false if it completed successfully.
  */
-int Fenix_check_cancelled(MPI_Request *request, MPI_Status *status);
-
+int Fenix_check_cancelled(MPI_Request* request, MPI_Status* status);
 
 /**
  * @brief Clean up Fenix state. Each active rank must call \c Fenix_Finalize before exiting.
- * 
- * This function cleans up all Fenix state, if any. If an MPI program using the Fenix library terminates
- * normally (i.e. not due to a call to \c MPI_Abort, or an unrecoverable error) then each rank must call
- * \c Fenix_Finalize before it exits. It must be called before \c MPI_Finalize, and after #Fenix_Init.
- * There shall be no function calls after this function, except #Fenix_Initialized.
  *
- * As noted in the description of #Fenix_Init, all spare ranks that have not been used to
- * recover from failures (and therefore are still reserved by Fenix and kept inside #Fenix_Init) will call 
+ * This function cleans up all Fenix state, if any. If an MPI program using the
+ * Fenix library terminates normally (i.e. not due to a call to \c MPI_Abort, or
+ * an unrecoverable error) then each rank must call
+ * \c Fenix_Finalize before it exits. It must be called before \c MPI_Finalize,
+ * and after #Fenix_Init. There shall be no function calls after this function,
+ * except #Fenix_Initialized.
+ *
+ * As noted in the description of #Fenix_Init, all spare ranks that have not
+ * been used to recover from failures (and therefore are still reserved by Fenix
+ * and kept inside #Fenix_Init) will call
  * \c MPI_Finalize and exit when all active ranks have called \c Fenix_Finalize.
  *
  * Supports inline recovery when it is active (see #Fenix_Mlog_activate). In
  * this case, a rank will not leave this function until success (or an error
  * with the message logs).
  *
- * **Advice**: Sometimes users may want to remove ranks proactively from the execution, for example because
- * monitoring data shows that failure of a rank is imminent or that a rank is executing un-manageably slowly.
- * This can be accomplished by calling \c exit on the targeted ranks, followed by an invocation of MPI_Barrier.
- * The removed ranks will be reported as failed and error handling will progress appropriately. No calls to finalize
- * are needed in this case.
+ * **Advice**: Sometimes users may want to remove ranks proactively from the
+ * execution, for example because monitoring data shows that failure of a rank
+ * is imminent or that a rank is executing un-manageably slowly. This can be
+ * accomplished by calling \c exit on the targeted ranks, followed by an
+ * invocation of MPI_Barrier. The removed ranks will be reported as failed and
+ * error handling will progress appropriately. No calls to finalize are needed
+ * in this case.
  */
 int Fenix_Finalize();
 
 /**@}*/
-
 
 /**
  * @defgroup DataRecovery Data Recovery
@@ -546,21 +553,21 @@ int Fenix_Finalize();
  *
  * @{
  */
-#define FENIX_DATA_GROUP_WORLD_ID            10
-#define FENIX_GROUP_ID_MAX                   11
-#define FENIX_DATA_MEMBER_ALL                -1
-#define FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER   11
-#define FENIX_DATA_MEMBER_ATTRIBUTE_COUNT    12
+#define FENIX_DATA_GROUP_WORLD_ID 10
+#define FENIX_GROUP_ID_MAX 11
+#define FENIX_DATA_MEMBER_ALL -1
+#define FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER 11
+#define FENIX_DATA_MEMBER_ATTRIBUTE_COUNT 12
 #define FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE 13
-#define FENIX_DATA_MEMBER_ATTRIBUTE_SIZE     14
-#define FENIX_DATA_SNAPSHOT_LATEST           -1
-#define FENIX_DATA_SNAPSHOT_ALL              -2
-#define FENIX_RESIZEABLE                      0
-#define FENIX_DATA_SUBSET_CREATED             2
-#define FENIX_STOREV_ALL                     -1
+#define FENIX_DATA_MEMBER_ATTRIBUTE_SIZE 14
+#define FENIX_DATA_SNAPSHOT_LATEST -1
+#define FENIX_DATA_SNAPSHOT_ALL -2
+#define FENIX_RESIZEABLE 0
+#define FENIX_DATA_SUBSET_CREATED 2
+#define FENIX_STOREV_ALL -1
 
-#define FENIX_DATA_POLICY_IN_MEMORY_RAID     13
-#define FENIX_DATA_POLICY_IMR                FENIX_DATA_POLICY_IN_MEMORY_RAID
+#define FENIX_DATA_POLICY_IN_MEMORY_RAID 13
+#define FENIX_DATA_POLICY_IMR FENIX_DATA_POLICY_IN_MEMORY_RAID
 
 #define FENIX_TIME_STAMP_IGNORE NULL
 
@@ -568,10 +575,9 @@ int Fenix_Finalize();
  * @unimplemented As MPI_Request, but for Fenix asynchronous data recovery calls
  */
 typedef struct {
-    MPI_Request mpi_send_req;
-    MPI_Request mpi_recv_req;
+  MPI_Request mpi_send_req;
+  MPI_Request mpi_recv_req;
 } Fenix_Request;
-
 
 /**
  * @brief Represents a data subset that can be stored/recovered
@@ -579,14 +585,13 @@ typedef struct {
  * Must be initialized (via #Fenix_Data_subset_create or
  * #Fenix_Data_subset_createv) before using as an input parameter.
  *
- * Must be uninitialized or deleted (#Fenix_Data_subset_delete) before using as an
- * output parameter to avoid data leaks.
+ * Must be uninitialized or deleted (#Fenix_Data_subset_delete) before using as
+ * an output parameter to avoid data leaks.
  */
 typedef struct {
-    //!@internal @brief pointer to a fenix::DataSubset object
-    void* impl;
+  //!@internal @brief pointer to a fenix::DataSubset object
+  void* impl;
 } Fenix_Data_subset;
-
 
 //!@brief A standin for checkpointing/recovering the full member's data
 extern const Fenix_Data_subset FENIX_DATA_SUBSET_FULL;
@@ -603,36 +608,38 @@ extern Fenix_Data_subset* FENIX_DATA_SUBSET_IGNORE;
  * @brief Create a Data Group
  * @qualifier collective
  *
- * If a group with this group_id was already created in the past and has not been deleted, the 
- * parameters of this call are ignored and this function simply serves to coordinate with any 
- * ranks that have not yet created this group (e.g. due to a failure).
+ * If a group with this group_id was already created in the past and has not
+ * been deleted, the parameters of this call are ignored and this function
+ * simply serves to coordinate with any ranks that have not yet created this
+ * group (e.g. due to a failure).
  *
- * All calling ranks must pass the same values for the parameters \c group_id, \c comm,
- * \c start_time_stamp, \c policy_name, and \c policy_value.
+ * All calling ranks must pass the same values for the parameters \c group_id,
+ * \c comm, \c start_time_stamp, \c policy_name, and \c policy_value.
  *
  * @param group_id A unique identifier to this group.
  * @param comm A resilient communicator on which the group is formed.
  * @param start_time_stamp The time_stamp to be used for the first commit in this group.
  * @param depth
  * @parblock
- * The number of successive snapshots of this group that are retained by Fenix, in 
- * addition to the most recent one, and that can be recovered by calling Fenix data member
- * restore functions.
- * 
- * For example, a depth of 0 means Fenix will keep only the necessary data to restore the
- * most recent snapshot, freeing or overwriting older snapshots automatically. A depth
- * of -1 is currently not supported, but would ordinarily indicate that no snapshots should
- * be removed automatically.
+ * The number of successive snapshots of this group that are retained by Fenix,
+ * in addition to the most recent one, and that can be recovered by calling
+ * Fenix data member restore functions.
+ *
+ * For example, a depth of 0 means Fenix will keep only the necessary data to
+ * restore the most recent snapshot, freeing or overwriting older snapshots
+ * automatically. A depth of -1 is currently not supported, but would ordinarily
+ * indicate that no snapshots should be removed automatically.
  * @endparblock
  * @param policy_name Currently, may only be FENIX_DATA_POLICY_IN_MEMORY_RAID
- * @param policy_value Pointer to data passed along to the policy. 
+ * @param policy_value Pointer to data passed along to the policy.
  *   See the specific policy for more information.
  * @param flag pointer to store policy-specific status or errors
  * @return FENIX_SUCCESS, or an error value.
  */
-int Fenix_Data_group_create(int group_id, MPI_Comm comm, int start_time_stamp,
-                            int depth, int policy_name, void* policy_value,
-                            int* flag);
+int Fenix_Data_group_create(
+  int group_id, MPI_Comm comm, int start_time_stamp, int depth, int policy_name,
+  void* policy_value, int* flag
+);
 
 /**
  * @brief Query if a data group exists on this rank
@@ -645,28 +652,32 @@ int Fenix_Data_group_created(int group_id);
 
 /**
  * @brief Create a data member for store/restore operations
- * @qualifier collective 
+ * @qualifier collective
  * @qualifier local
  *
- * All calling ranks in the group's communicator must pass the same values for the parameters
+ * All calling ranks in the group's communicator must pass the same values for
+ * the parameters
  * \c member_id, \c datatype, and \c group_id.
  *
  * @param group_id Identifier to a data group within which to create the member.
- * @param member_id An integer unique within the data group that identifies the data in 
- *        \c source_buffer. Must be nonnegative and less than FENIX_MEMBER_ID_MAX, which is 
- *        guaranteed to be at least 2^30.
- * @param buffer Address of the data to be copied to redundant storage maintained by Fenix.
- *        Note that this parameter may also be specified using #Fenix_Data_member_attr_set, which
- *        is critical for non-survivor ranks after a failure which will have an invalid address
- *        which was generated on the failed rank and must update.
- * @param count The maximum number of contiguous elements of type \c datatype of the data to be
- *        stored. A value of FENIX_RESIZEABLE allows this member to have a varying data size.
+ * @param member_id An integer unique within the data group that identifies the
+ *        data in \c source_buffer. Must be nonnegative and less than
+ *        FENIX_MEMBER_ID_MAX, which is guaranteed to be at least 2^30.
+ * @param buffer Address of the data to be copied to redundant storage
+ *        maintained by Fenix. Note that this parameter may also be specified
+ *        using #Fenix_Data_member_attr_set, which is critical for non-survivor
+ *        ranks after a failure which will have an invalid address which was
+ *        generated on the failed rank and must update.
+ * @param count The maximum number of contiguous elements of type \c datatype of
+ *        the data to be stored. A value of FENIX_RESIZEABLE allows this member
+ *        to have a varying data size.
  * @param datatype The MPI_Datatype of the elements in \c source_buffer
  *
  * @return FENIX_SUCCESS, or an error value.
  */
-int Fenix_Data_member_create(int group_id, int member_id, void *buffer,
-                             int count, MPI_Datatype datatype);
+int Fenix_Data_member_create(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
+);
 
 /**
  * @brief Query if a data member exists on this rank
@@ -680,24 +691,25 @@ int Fenix_Data_member_created(int group_id, int member_id);
 
 /**
  * @brief Get the storage policy of a data group
- * 
+ *
  * @param group_id Identified to the data group to query
  * @param policy_name The identifier of the policy name of the data group.
- * @param policy_value A location within which to store the policy_values this group's
- *        policy was configured with.
+ * @param policy_value A location within which to store the policy_values this
+ *        group's policy was configured with.
  * @param flag A location set to true if a policy value was extracted, else false.
  * @return FENIX_SUCCESS, or an error value.
  */
-int Fenix_Data_group_get_redundancy_policy(int group_id, int* policy_name,
-                                           void *policy_value, int *flag);
+int Fenix_Data_group_get_redundancy_policy(
+  int group_id, int* policy_name, void* policy_value, int* flag
+);
 
-//!@unimplemented Block on completion of the store operation specified by the request.
+//!@unimplemented Block on completion of the store operation specified by the
+//! request.
 int Fenix_Data_wait(Fenix_Request request);
 
-
-//!@unimplemented Query completion of the store operation specified by the request.
-int Fenix_Data_test(Fenix_Request request, int *flag);
-
+//!@unimplemented Query completion of the store operation specified by the
+//! request.
+int Fenix_Data_test(Fenix_Request request, int* flag);
 
 /**
  * @brief Serialize a group member's data into the member's local store.
@@ -716,39 +728,49 @@ int Fenix_Data_test(Fenix_Request request, int *flag);
  *        FENIX_DATA_SUBSET_PRESTAGED is invalid.
  * @returnstatus
  **/
-int Fenix_Data_member_stage(int group_id, int member_id,
-                            const Fenix_Data_subset subset_specifier);
+int Fenix_Data_member_stage(
+  int group_id, int member_id, const Fenix_Data_subset subset_specifier
+);
 
 /**
- * @brief Store a particular group member into the group's resilient storage space, in uncommitted storage.
+ * @brief Store a particular group member into the group's resilient storage
+ *  space, in uncommitted storage.
+ *
  * @qualifier collective
  *
- * The user can safely modify the member's data buffer after this call, as the current state is copied immediately.
- * Multiple calls may be used to incrementally store data (using subset_specifiers), or overwrite old data prior to a commit.
+ * The user can safely modify the member's data buffer after this call, as the
+ * current state is copied immediately. Multiple calls may be used to
+ * incrementally store data (using subset_specifiers), or overwrite old data
+ * prior to a commit.
  *
  * @param group_id All ranks must provide the same group_id
  * @param member_id All ranks must provide the same member_id
  * @param subset_specifier Which subset of the data to store.
- *        If this member was created with size FENIX_RESIZEABLE, FENIX_DATA_SUBSET_ALL is an invalid input.
+ *        If this member was created with size FENIX_RESIZEABLE,
+ * FENIX_DATA_SUBSET_ALL is an invalid input.
  * @return FENIX_SUCCESS, or an error value.
  */
-int Fenix_Data_member_store(int group_id, int member_id,
-                            const Fenix_Data_subset subset_specifier);
+int Fenix_Data_member_store(
+  int group_id, int member_id, const Fenix_Data_subset subset_specifier
+);
 
-
-//!@unimplemented As [store](#Fenix_Data_member_store), but subsets may vary rank-to-rank.
-int Fenix_Data_member_storev(int group_id, int member_id,
-                             const Fenix_Data_subset subset_specifier);
+//!@unimplemented As [store](#Fenix_Data_member_store), but subsets may vary
+//!rank-to-rank.
+int Fenix_Data_member_storev(
+  int group_id, int member_id, const Fenix_Data_subset subset_specifier
+);
 
 //!@unimplemented As [store](#Fenix_Data_member_store), but asynchronous.
-int Fenix_Data_member_istore(int group_id, int member_id,
-                             const Fenix_Data_subset subset_specifier,
-                             Fenix_Request *request);
+int Fenix_Data_member_istore(
+  int group_id, int member_id, const Fenix_Data_subset subset_specifier,
+  Fenix_Request* request
+);
 
 //!@unimplemented As [istore](#Fenix_Data_member_istore), but asynchronous.
-int Fenix_Data_member_istorev(int group_id, int member_id,
-                              const Fenix_Data_subset subset_specifier,
-                              Fenix_Request *request);
+int Fenix_Data_member_istorev(
+  int group_id, int member_id, const Fenix_Data_subset subset_specifier,
+  Fenix_Request* request
+);
 
 /**
  * @brief Commit stored data members to the group's next snapshot.
@@ -757,21 +779,23 @@ int Fenix_Data_member_istorev(int group_id, int member_id,
  *
  * This function is used to freeze the current state of a data group,
  * together with all its application data that has been stored in Fenix’
- * redundant storage, and label it with a time stamp, thus creating a 
- * snapshot of the stored application data. Only data that has been 
- * committed is eligible for recovery through #Fenix_Data_member_restore. 
- * An application needs to call #Fenix_Data_wait for all pending asynchronous 
- * [Fenix_Data_member_istore(v)](@ref Fenix_Data_member_istore) operations 
+ * redundant storage, and label it with a time stamp, thus creating a
+ * snapshot of the stored application data. Only data that has been
+ * committed is eligible for recovery through #Fenix_Data_member_restore.
+ * An application needs to call #Fenix_Data_wait for all pending asynchronous
+ * [Fenix_Data_member_istore(v)](@ref Fenix_Data_member_istore) operations
  * in the group before committing.
  *
  * @param[in] group_id The group to commit
  * @param[out] time_stamp The time stamp of the new snapshot
  * @returnstatus
  */
-int Fenix_Data_commit(int group_id, int *time_stamp);
+int Fenix_Data_commit(int group_id, int* time_stamp);
 
 /**
- * @brief As [commit](#Fenix_Data_commit), but ensures a globally consistent commit.
+ * @brief As [commit](#Fenix_Data_commit), but ensures a globally consistent
+ * commit.
+ *
  * @qualifier collective
  *
  * This function does not function as a traditional barrier.
@@ -783,7 +807,7 @@ int Fenix_Data_commit(int group_id, int *time_stamp);
  * @param[out] time_stamp The time stamp of the new snapshot
  * @returnstatus
  */
-int Fenix_Data_commit_barrier(int group_id, int *time_stamp);
+int Fenix_Data_commit_barrier(int group_id, int* time_stamp);
 
 /**
  * @brief Store all members of a group and then commit that group.
@@ -809,8 +833,10 @@ int Fenix_Data_commit_barrier(int group_id, int *time_stamp);
  * @param[out] time_stamp Pointer to store the time stamp of the commit to, or
  *                        FENIX_TIME_STAMP_IGNORE.
  */
-int Fenix_Data_checkpoint(int group_id, const Fenix_Data_subset subset,
-                          int num_storev, int* storev_ids, int* time_stamp);
+int Fenix_Data_checkpoint(
+  int group_id, const Fenix_Data_subset subset, int num_storev, int* storev_ids,
+  int* time_stamp
+);
 
 //!@unimplemented Block until all ranks in the group have reached this point.
 int Fenix_Data_barrier(int group_id);
@@ -819,16 +845,16 @@ int Fenix_Data_barrier(int group_id);
  * @brief Restore the data of a group member from a snapshot.
  * @qualifier collective
  *
- * All ranks in the group’s resilient communicator must pass the 
+ * All ranks in the group’s resilient communicator must pass the
  * same values for the parameters group_id, member_id, and time_stamp.
  * This function is used to retrieve data from consistent snapshot
- * members. This function can only be used if the size of the 
+ * members. This function can only be used if the size of the
  * communicator used to store the data is the same as that at the time
  * of data recovery (this implies non-shrinking communicator recovery
  * in case of a rank loss).
  *
  * If the size of the buffer needing to receive the recovery data is
- * unknown for a particular rank, it can be queried using 
+ * unknown for a particular rank, it can be queried using
  * #Fenix_Data_member_attr_get.
  *
  * @param[in] group_id The group to restore from
@@ -839,8 +865,10 @@ int Fenix_Data_barrier(int group_id);
  * @param[out] found_data The subset of the data that was found in the snapshot
  * @returnstatus
  */
-int Fenix_Data_member_restore(int group_id, int member_id, void *target_buffer,
-                              int max_count, int time_stamp, Fenix_Data_subset* found_data);
+int Fenix_Data_member_restore(
+  int group_id, int member_id, void* target_buffer, int max_count,
+  int time_stamp, Fenix_Data_subset* found_data
+);
 
 /**
  * @brief Local-only version of Fenix_Data_member_restore
@@ -856,22 +884,26 @@ int Fenix_Data_member_restore(int group_id, int member_id, void *target_buffer,
  * @param[out] found_data The subset of the data that was found in the snapshot
  * @returnstatus
  */
-int Fenix_Data_member_lrestore(int group_id, int member_id, void *target_buffer,
-                              int max_count, int time_stamp, Fenix_Data_subset* found_data);
+int Fenix_Data_member_lrestore(
+  int group_id, int member_id, void* target_buffer, int max_count,
+  int time_stamp, Fenix_Data_subset* found_data
+);
 
-//!@unimplemented As #Fenix_Data_member_restore, but restores from a specific rank's data.
-int Fenix_Data_member_restore_from_rank(int group_id, int member_id, void *data,
-                                        int max_count, int time_stamp,
-                                        Fenix_Data_subset* found_data, int source_rank);
+//!@unimplemented As #Fenix_Data_member_restore, but restores from a specific
+//!rank's data.
+int Fenix_Data_member_restore_from_rank(
+  int group_id, int member_id, void* data, int max_count, int time_stamp,
+  Fenix_Data_subset* found_data, int source_rank
+);
 
 /**
  * @brief Create a data subset for use in store operations.
  *
- * Creates a subset based on num_blocks pairs of 
- * {start_offset,end_offset}, 
- * {start_offset+stride,end_offset+stride}, 
+ * Creates a subset based on num_blocks pairs of
+ * {start_offset,end_offset},
+ * {start_offset+stride,end_offset+stride},
  * {start_offset+2*stride,end_offset+2*stride},
- * etc. 
+ * etc.
  *
  * The value of start_offset must be smaller than or equal
  * to the value of end_offset to indicate non-negative block
@@ -881,14 +913,17 @@ int Fenix_Data_member_restore_from_rank(int group_id, int member_id, void *data,
  * to free memory.
  *
  * @param[in] num_blocks The number of contiguous data blocks.
- * @param[in] start_offset The index of the first element in the first data block.
+ * @param[in] start_offset The index of the first element in the first data
+ *                         block.
  * @param[in] end_offset The index of the last element in the first data block.
  * @param[in] stride Regular shift between successive data blocks.
  * @param[out] subset_specifier The created subset.
  * @returnstatus
  */
-int Fenix_Data_subset_create(int num_blocks, int start_offset, int end_offset,
-                             int stride, Fenix_Data_subset *subset_specifier);
+int Fenix_Data_subset_create(
+  int num_blocks, int start_offset, int end_offset, int stride,
+  Fenix_Data_subset* subset_specifier
+);
 
 /**
  * @brief As #Fenix_Data_subset_create, but with varying start and end offsets.
@@ -902,13 +937,16 @@ int Fenix_Data_subset_create(int num_blocks, int start_offset, int end_offset,
  * to free memory.
  *
  * @param[in] num_blocks The number of contiguous data blocks.
- * @param[in] array_start_offsets The index of the first element in each data block.
- * @param[in] array_end_offsets The index of the last element in each data block.
+ * @param[in] array_start_offsets The index of the first element in each data
+ *            block.
+ * @param[in] array_end_offsets The index of the last element in each data
+ *            block.
  * @param[out] subset_specifier The created subset.
  */
-int Fenix_Data_subset_createv(int num_blocks, int *array_start_offsets,
-                              int *array_end_offsets,
-                              Fenix_Data_subset *subset_specifier);
+int Fenix_Data_subset_createv(
+  int num_blocks, int* array_start_offsets, int* array_end_offsets,
+  Fenix_Data_subset* subset_specifier
+);
 
 /**
  * @brief Delete a data subset.
@@ -918,7 +956,7 @@ int Fenix_Data_subset_createv(int num_blocks, int *array_start_offsets,
  * @param[in] subset_specifier The subset to delete.
  * @returnstatus
  */
-int Fenix_Data_subset_delete(Fenix_Data_subset *subset_specifier);
+int Fenix_Data_subset_delete(Fenix_Data_subset* subset_specifier);
 
 /**
  * @brief Get the number of members in a data group.
@@ -926,7 +964,9 @@ int Fenix_Data_subset_delete(Fenix_Data_subset *subset_specifier);
  * @param[in] group_id The group to query
  * @param[out] number_of_members Number of members in the group
  */
-int Fenix_Data_group_get_number_of_members(int group_id, int *number_of_members);
+int Fenix_Data_group_get_number_of_members(
+  int group_id, int* number_of_members
+);
 
 /**
  * @brief Get member ID based on member index
@@ -937,8 +977,9 @@ int Fenix_Data_group_get_number_of_members(int group_id, int *number_of_members)
  * @param[out] member_id The member id at this index in the group
  * @param[in] position The position to check, [0, number_of_members)
  */
-int Fenix_Data_group_get_member_at_position(int group_id, int *member_id,
-                                            int position);
+int Fenix_Data_group_get_member_at_position(
+  int group_id, int* member_id, int position
+);
 
 /**
  * @brief Get the number of locally-available snapshots in a data group.
@@ -949,8 +990,9 @@ int Fenix_Data_group_get_member_at_position(int group_id, int *member_id,
  * @param[out] number_of_snapshots The number of snapshots in the group
  * @returnstatus
  */
-int Fenix_Data_group_get_number_of_snapshots(int group_id,
-                                             int *number_of_snapshots);
+int Fenix_Data_group_get_number_of_snapshots(
+  int group_id, int* number_of_snapshots
+);
 
 /**
  * @brief Get the time stamp of a snapshot at a given index.
@@ -959,26 +1001,30 @@ int Fenix_Data_group_get_number_of_snapshots(int group_id,
  * (e.g. the most recent available snapshot has position=0).
  *
  * @param[in] group_id The group to query
- * @param[in] position The index of the snapshot, which must be [0, number_of_snapshots)
+ * @param[in] position The index of the snapshot, which must be
+ *            [0, number_of_snapshots)
  * @param[out] time_stamp The time stamp of the snapshot
  *
  */
-int Fenix_Data_group_get_snapshot_at_position(int group_id, int position,
-                                              int *time_stamp);
+int Fenix_Data_group_get_snapshot_at_position(
+  int group_id, int position, int* time_stamp
+);
 
 //!@unimplemented Get the value of a member's attribute.
-int Fenix_Data_member_attr_get(int group_id, int member_id, int attributename,
-                               void *attributevalue, int *flag, int source_rank);
+int Fenix_Data_member_attr_get(
+  int group_id, int member_id, int attributename, void* attributevalue,
+  int* flag, int source_rank
+);
 
 /**
  * @brief Set the value of a member's attribute.
  *
- * Valid names are FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER, FENIX_DATA_MEMBER_ATTRIBUTE_COUNT,
- * and FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE.
+ * Valid names are FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER,
+ * FENIX_DATA_MEMBER_ATTRIBUTE_COUNT, and FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE.
  *
- * The COUNT and DATATYPE attributes may only be set before the first store operation.
- * Contrary to the Fenix specification, returning to #Fenix_Init after a failure does not 
- * allow the user to set these attributes again.
+ * The COUNT and DATATYPE attributes may only be set before the first store
+ * operation. Contrary to the Fenix specification, returning to #Fenix_Init
+ * after a failure does not allow the user to set these attributes again.
  *
  * @param[in] group_id The group to update
  * @param[in] member_id The member to update
@@ -987,13 +1033,15 @@ int Fenix_Data_member_attr_get(int group_id, int member_id, int attributename,
  * @param[out] flag Set to true if the attribute was set, else false
  * @returnstatus
  */
-int Fenix_Data_member_attr_set(int group_id, int member_id, int attribute_name,
-                               void *attribute_value, int *flag);
+int Fenix_Data_member_attr_set(
+  int group_id, int member_id, int attribute_name, void* attribute_value,
+  int* flag
+);
 
 /**
  * @brief Delete a snapshot from a data group.
  * @qualifier local
- * 
+ *
  * @param[in] group_id The group to delete from
  * @param[in] time_stamp The time stamp of the snapshot to delete
  * @returnstatus
@@ -1027,7 +1075,7 @@ int Fenix_Data_member_delete(int group_id, int member_id);
  * @{
  */
 
-#define FENIX_MLOG_NONE     -1
+#define FENIX_MLOG_NONE -1
 #define FENIX_MLOG_CONTINUE -1
 
 /**
@@ -1122,9 +1170,9 @@ int Fenix_Mlog_sync(int mlog_id, int region_id);
  * @param[in] mlog_id   The mlog to stage.
  * @param[in] group_id  The group to stage into.
  * @param[in] member_id The member to stage into.
- *                      The member does not have to already exist.
- *                      If the member already exists, it must have been created
- *                      with size FENIX_RESIZEABLE and datatype MPI_BYTE
+ *            The member does not have to already exist.
+ *            If the member already exists, it must have been created with size
+ *            FENIX_RESIZEABLE and datatype MPI_BYTE
  * @returnstatus
  */
 int Fenix_Mlog_stage(int mlog_id, int group_id, int member_id);
@@ -1139,8 +1187,9 @@ int Fenix_Mlog_stage(int mlog_id, int group_id, int member_id);
  * @param[in] time_stamp The time stamp of the snapshot to restore from.
  * @returnstatus
  */
-int Fenix_Mlog_lrestore(int mlog_id, int group_id, int member_id,
-                        int time_stamp);
+int Fenix_Mlog_lrestore(
+  int mlog_id, int group_id, int member_id, int time_stamp
+);
 
 /**
  * @brief Delete an mlog

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -217,7 +217,7 @@ bool member_created(int group_id, int member_id);
 
 //!@brief Overload of #Fenix_Data_member_stage
 int member_stage(
-    int group_id, int member_id, const DataSubset& subset = SUBSET_FULL
+  int group_id, int member_id, const DataSubset& subset = SUBSET_FULL
 );
 
 //!@brief Overload of #Fenix_Data_member_store
@@ -226,14 +226,14 @@ int member_store(
 );
 //!@brief Overload of #Fenix_Data_member_store, stores all members
 inline int member_store(int group_id, const DataSubset& subset = SUBSET_FULL) {
-    return member_store(group_id, FENIX_DATA_MEMBER_ALL, subset);
+  return member_store(group_id, FENIX_DATA_MEMBER_ALL, subset);
 }
 
 //!@brief Overload of #Fenix_Data_member_storev
 int member_storev(int group_id, int member_id, const DataSubset& subset);
 //!@brief Overload of #Fenix_Data_member_storev, stores all members
 inline int member_storev(int group_id, const DataSubset& subset) {
-    return member_storev(group_id, FENIX_DATA_MEMBER_ALL, subset);
+  return member_storev(group_id, FENIX_DATA_MEMBER_ALL, subset);
 }
 
 //!@brief Overload of #Fenix_Data_member_istore
@@ -242,14 +242,14 @@ int member_istore(
 );
 
 struct MemberIstoreArgs {
-    int member_id = FENIX_DATA_MEMBER_ALL;
-    const DataSubset& subset = SUBSET_FULL;
+  int member_id            = FENIX_DATA_MEMBER_ALL;
+  const DataSubset& subset = SUBSET_FULL;
 };
 //!@brief Overload of #Fenix_Data_member_istore
 inline int member_istore(
-    int group_id, Fenix_Request* request, MemberIstoreArgs args = {}
+  int group_id, Fenix_Request* request, MemberIstoreArgs args = {}
 ) {
-    return member_istore(group_id, args.member_id, args.subset, request);
+  return member_istore(group_id, args.member_id, args.subset, request);
 }
 
 //!@brief Overload of #Fenix_Data_member_istorev
@@ -258,15 +258,15 @@ int member_istorev(
 );
 //!@brief Overload of #Fenix_Data_member_istorev, stores all members
 inline int member_istorev(
-    int group_id, const DataSubset& subset, Fenix_Request* request
+  int group_id, const DataSubset& subset, Fenix_Request* request
 ) {
-    return member_istorev(group_id, FENIX_DATA_MEMBER_ALL, subset, request);
+  return member_istorev(group_id, FENIX_DATA_MEMBER_ALL, subset, request);
 }
 
 //!@brief Overload of #Fenix_Data_member_restore
 int member_restore(
   int group_id, int member_id, void* target_buffer, int max_length,
-  int time_stamp = FENIX_DATA_SNAPSHOT_LATEST,
+  int time_stamp         = FENIX_DATA_SNAPSHOT_LATEST,
   DataSubset& data_found = SUBSET_IGNORE
 );
 
@@ -341,8 +341,8 @@ int stage(int mlog_id, int group_id, int member_id);
 
 //@brief Overload of #Fenix_Mlog_lrestore
 int lrestore(
-    int mlog_id, int group_id, int member_id,
-    int time_stamp = FENIX_DATA_SNAPSHOT_LATEST
+  int mlog_id, int group_id, int member_id,
+  int time_stamp = FENIX_DATA_SNAPSHOT_LATEST
 );
 
 //@brief Overload of #Fenix_Mlog_delete

--- a/include/fenix/logging/collective_log_holder.h
+++ b/include/fenix/logging/collective_log_holder.h
@@ -24,7 +24,7 @@ class CollectiveLogHolder {
   CollectiveLogHolder() = default;
   CollectiveLogHolder(CollectiveLogHolder&& o) { *this = std::move(o); }
   CollectiveLogHolder& operator=(CollectiveLogHolder&& o) {
-    log = std::move(o.log);
+    log     = std::move(o.log);
     variant = std::move(o.variant);
     return *this;
   }

--- a/include/fenix/logging/comm_log.h
+++ b/include/fenix/logging/comm_log.h
@@ -30,7 +30,7 @@ struct CRegion {
   bool fresh() const { return empty() && first == 0; }
   std::string str() const {
     return "Region " + std::to_string(id) + " [" + std::to_string(first) + "," +
-           std::to_string(next) + ")";
+      std::to_string(next) + ")";
   }
 };
 
@@ -96,8 +96,8 @@ struct CommLog {
 
   std::string str(bool with_region = false) const {
     return "Rank " + std::to_string(m_rank) +
-           " (active=" + std::to_string(active_region) + ")" +
-           (with_region ? " " + region().str() : "");
+      " (active=" + std::to_string(active_region) + ")" +
+      (with_region ? " " + region().str() : "");
   }
 
  private:

--- a/include/fenix/logging/message_logging.h
+++ b/include/fenix/logging/message_logging.h
@@ -8,7 +8,7 @@
 #include "fenix_ext.hpp"
 #include "fenix/logging/comm_log.h"
 
-#define CONSISTENCY_TAG            22234652
+#define CONSISTENCY_TAG 22234652
 #define COLLECTIVE_CONSISTENCY_TAG 22234653
 
 namespace fenix::mlog {

--- a/include/fenix/logging/op_log.h
+++ b/include/fenix/logging/op_log.h
@@ -32,11 +32,11 @@ class OpLog {
   MPI_Request* req() const { return m_req; }
   int idx() const { return m_idx; }
 
-  OpLog(const OpLog&) = delete;
+  OpLog(const OpLog&)            = delete;
   OpLog& operator=(const OpLog&) = delete;
 
   virtual void serialize_impl(std::ostream& o) const = 0;
-  virtual std::string str() const = 0;
+  virtual std::string str() const                    = 0;
 
  protected:
   OpLog() : m_idx(-1) {}
@@ -64,7 +64,7 @@ class OpLog {
 
  private:
   mutable MPI_Request req_obj = MPI_REQUEST_NULL;
-  mutable MPI_Request* m_req = &req_obj;
+  mutable MPI_Request* m_req  = &req_obj;
 };
 
 template <auto MPIFunction>
@@ -95,17 +95,17 @@ class MPIBuffer {
   MPIBuffer() = default;
 
   // No copying, move-only
-  MPIBuffer(const MPIBuffer&) = delete;
+  MPIBuffer(const MPIBuffer&)              = delete;
   MPIBuffer& operator=(const MPIBuffer& o) = delete;
   MPIBuffer(MPIBuffer&& o) { *this = std::move(o); }
   MPIBuffer& operator=(MPIBuffer&& o) {
-    m_count = o.m_count;
-    o.m_count = 0;
-    m_type = o.m_type;
-    o.m_type = MPI_DATATYPE_NULL;
+    m_count      = o.m_count;
+    o.m_count    = 0;
+    m_type       = o.m_type;
+    o.m_type     = MPI_DATATYPE_NULL;
     internal_buf = std::move(o.internal_buf);
-    user_buf = o.user_buf;
-    o.user_buf = nullptr;
+    user_buf     = o.user_buf;
+    o.user_buf   = nullptr;
     return *this;
   }
 
@@ -193,7 +193,7 @@ class MPIBuffer {
   // operations. In that case, we don't serialize the data
   mutable bool garbage_data = false;
 
-  int m_count = 0;
+  int m_count         = 0;
   MPI_Datatype m_type = MPI_DATATYPE_NULL;
 };
 

--- a/include/fenix/logging/ops/allreduce_log.h
+++ b/include/fenix/logging/ops/allreduce_log.h
@@ -21,7 +21,7 @@ class AllreduceLog : public CollectiveLog {
   AllreduceLog(AllreduceLog&& o) { *this = std::move(o); }
   AllreduceLog& operator=(AllreduceLog&& o) {
     CollectiveLog::operator=(std::move(o));
-    op = o.op;
+    op   = o.op;
     sbuf = std::move(o.sbuf);
     rbuf = std::move(o.rbuf);
     return *this;

--- a/include/fenix/logging/ops/bcast_log.h
+++ b/include/fenix/logging/ops/bcast_log.h
@@ -26,7 +26,7 @@ class BcastLog : public CollectiveLog {
   BcastLog& operator=(BcastLog&& o) {
     CollectiveLog::operator=(std::move(o));
     root = o.root;
-    buf = std::move(o.buf);
+    buf  = std::move(o.buf);
     return *this;
   }
 

--- a/include/fenix/logging/ops/irecv_log.h
+++ b/include/fenix/logging/ops/irecv_log.h
@@ -13,18 +13,18 @@ struct IrecvLog {
   IrecvLog(void* b, int c, MPI_Datatype d, int t, MPI_Request* r)
     : buf(b), count(c), datatype(d), tag(t), request(r) {}
   IrecvLog& operator=(const IrecvLog& o) {
-    buf = o.buf;
-    count = o.count;
+    buf      = o.buf;
+    count    = o.count;
     datatype = o.datatype;
-    tag = o.tag;
-    request = o.request;
+    tag      = o.tag;
+    request  = o.request;
     return *this;
   }
 
   void* buf = nullptr;
   int count = -1;
   MPI_Datatype datatype;
-  int tag = -1;
+  int tag              = -1;
   MPI_Request* request = nullptr;
 
   int irecv(int src, MPI_Comm comm) {

--- a/include/fenix/logging/ops/reduce_log.h
+++ b/include/fenix/logging/ops/reduce_log.h
@@ -25,7 +25,7 @@ class ReduceLog : public CollectiveLog {
   ReduceLog& operator=(ReduceLog&& o) {
     CollectiveLog::operator=(std::move(o));
     root = o.root;
-    op = o.op;
+    op   = o.op;
     sbuf = std::move(o.sbuf);
     rbuf = std::move(o.rbuf);
     return *this;
@@ -53,7 +53,7 @@ class ReduceLog : public CollectiveLog {
   int begin(MPI_Comm c) const override {
     req_free();
     void* recv = root == util::comm_rank(c) ? rbuf.buf() : nullptr;
-    int ret = PMPI_Ireduce(sbuf, recv, sbuf, sbuf, op, root, c, req());
+    int ret    = PMPI_Ireduce(sbuf, recv, sbuf, sbuf, op, root, c, req());
     if (ret == MPI_SUCCESS) ret = PMPI_Wait(req(), MPI_STATUS_IGNORE);
     // Release references to any user buffers if we get this far
     rbuf.release_user_buf();
@@ -63,7 +63,7 @@ class ReduceLog : public CollectiveLog {
   void replay(MPI_Comm c) const override {
     req_free();
     void* recv = root == util::comm_rank(c) ? rbuf.buf() : nullptr;
-    int ret = PMPI_Ireduce(sbuf, recv, sbuf, sbuf, op, root, c, req());
+    int ret    = PMPI_Ireduce(sbuf, recv, sbuf, sbuf, op, root, c, req());
     fenix_assert(
       ret == MPI_SUCCESS, "Non-process MPI error during collective replay\n"
     );

--- a/include/fenix/logging/rank_log.h
+++ b/include/fenix/logging/rank_log.h
@@ -49,7 +49,7 @@ struct Region {
   auto operator==(const int& i) const { return id == i; }
   std::string str() const {
     return "Region " + std::to_string(id) + " (send:" + send.str() +
-           ",recv:" + recv.str() + ")";
+      ",recv:" + recv.str() + ")";
   }
 };
 
@@ -106,8 +106,8 @@ struct RankLog {
 
  public:
   Region& cur_region = regions.back();
-  int& next_send = cur_region.send.next;
-  int& next_recv = cur_region.recv.next;
+  int& next_send     = cur_region.send.next;
+  int& next_recv     = cur_region.recv.next;
 };
 } //namespace fenix::logging
 #endif

--- a/include/fenix/logging/serialize.h
+++ b/include/fenix/logging/serialize.h
@@ -161,8 +161,7 @@ void read(std::istream& s, MPI_Op& d);
 template <typename T>
 struct writable {
   static constexpr bool value = Serializable<T> ||
-                                std::is_same_v<T, MPI_Datatype> ||
-                                std::is_same_v<T, MPI_Op>;
+    std::is_same_v<T, MPI_Datatype> || std::is_same_v<T, MPI_Op>;
 };
 template <template <typename...> typename Base, typename T, typename... Args>
 struct writable<Base<T, Args...>> {
@@ -173,14 +172,12 @@ struct writable<Base<T, Args...>> {
 template <typename T>
 struct readable {
   static constexpr bool value = Deserializable<T> ||
-                                std::is_same_v<T, MPI_Datatype> ||
-                                std::is_same_v<T, MPI_Op>;
+    std::is_same_v<T, MPI_Datatype> || std::is_same_v<T, MPI_Op>;
 };
 template <template <typename...> typename Base, typename T, typename... Args>
 struct readable<Base<T, Args...>> {
   static constexpr bool value = DeserializableVector<T> ||
-                                DeserializableSet<T> ||
-                                DeserializableOptional<T>;
+    DeserializableSet<T> || DeserializableOptional<T>;
 };
 
 template <typename T>

--- a/include/fenix/mpi_util.hpp
+++ b/include/fenix/mpi_util.hpp
@@ -72,7 +72,7 @@ enum Tag {
 };
 
 // MPI Standard guarantees tags below 2^15 are valid
-static_assert(FENIX_TAG_MAX < 1<<15);
+static_assert(FENIX_TAG_MAX < (1 << 15));
 
 } // namespace fenix::tags
 
@@ -80,10 +80,10 @@ namespace fenix::util {
 
 inline std::string mpi_error_string(int errcode) {
   std::string ret;
-  ret.resize(MPI_MAX_ERROR_STRING+1);
+  ret.resize(MPI_MAX_ERROR_STRING + 1);
   int len;
   MPI_Error_string(errcode, &ret[0], &len);
-  ret.resize(len+1);
+  ret.resize(len + 1);
   return ret;
 }
 

--- a/include/fenix_data_group.hpp
+++ b/include/fenix_data_group.hpp
@@ -72,83 +72,98 @@ namespace fenix::data {
 //We keep basic bookkeeping info here, policy specific
 //information is kept by the policy's data type.
 struct fenix_group_t {
-    fenix_group_t(
-        int groupid, MPI_Comm c, int timestart, int depth, int policy
-    );
+  fenix_group_t(int groupid, MPI_Comm c, int timestart, int depth, int policy);
 
-    int groupid;
-    MPI_Comm comm;
-    int comm_size;
-    int current_rank;
-    int timestart;
-    int timestamp;
-    int depth;
-    int policy_name;
-    std::unordered_map<int, fenix_member_entry_t> members;
-    // Kept in order of creation
-    std::vector<int> member_order;
+  int groupid;
+  MPI_Comm comm;
+  int comm_size;
+  int current_rank;
+  int timestart;
+  int timestamp;
+  int depth;
+  int policy_name;
+  std::unordered_map<int, fenix_member_entry_t> members;
+  // Kept in order of creation
+  std::vector<int> member_order;
 
-    std::vector<int> get_member_ids();
-    //Search for id, returning null if not found.
-    fenix_member_entry_t* search_member(int id);
-    //As search_member, but throw if not found
-    fenix_member_entry_t* find_member(
-        int id, std::source_location loc = std::source_location::current()
-    );
-    int member_create(int id, void* data, int count, MPI_Datatype datatype);
-    int member_create(int id, void* data, int count, int datatype_size);
-    int member_delete(int memberid);
-    
-    virtual int group_delete() = 0;
-    virtual int member_create(fenix_member_entry_t* member) = 0;
-    virtual int member_delete(fenix_member_entry_t* member) = 0;
-    virtual int get_redundant_policy(int* name, void* value, int* flag) = 0;
-    virtual void member_stage(int memberid, const DataSubset& subset) = 0;
-    virtual int member_store(int memberid, const DataSubset& subset) = 0;
-    virtual int member_storev(int memberid, const DataSubset& subset) = 0;
-    virtual int member_istore(int memberid, const DataSubset& subset, Fenix_Request* req) = 0;
-    virtual int member_istorev(int memberid, const DataSubset& subset, Fenix_Request* req) = 0;
-    virtual int commit() = 0;
-    virtual int snapshot_delete(int timestamp) = 0;
-    virtual int barrier() = 0;
-    virtual int member_restore(int member_id, void* target_bugger, int max, int timestamp, DataSubset& data_found) = 0;
-    virtual int member_lrestore(int member_id, void* target_bugger, int max, int timestamp, DataSubset& data_found) = 0;
-    virtual int member_restore_from_rank(int member_id, void* target_bugger, int max, int timestamp, int source_rank) = 0;
-    virtual int get_number_of_snapshots(int* num) = 0;
-    virtual int get_snapshot_at_position(int position, int* timestamp) = 0;
-    virtual std::vector<int> get_snapshots() = 0;
-    virtual int reinit(int* flag) = 0;
-    virtual int member_get_attribute(fenix_member_entry_t* mentry, int name, void* value, int* flag, int sourcerank) = 0;
-    virtual int member_set_attribute(fenix_member_entry_t* mentry, int name, void* value, int* flag) = 0;
+  std::vector<int> get_member_ids();
+  //Search for id, returning null if not found.
+  fenix_member_entry_t* search_member(int id);
+  //As search_member, but throw if not found
+  fenix_member_entry_t* find_member(
+    int id, std::source_location loc = std::source_location::current()
+  );
+  int member_create(int id, void* data, int count, MPI_Datatype datatype);
+  int member_create(int id, void* data, int count, int datatype_size);
+  int member_delete(int memberid);
+
+  virtual int group_delete()                                          = 0;
+  virtual int member_create(fenix_member_entry_t* member)             = 0;
+  virtual int member_delete(fenix_member_entry_t* member)             = 0;
+  virtual int get_redundant_policy(int* name, void* value, int* flag) = 0;
+  virtual void member_stage(int memberid, const DataSubset& subset)   = 0;
+  virtual int member_store(int memberid, const DataSubset& subset)    = 0;
+  virtual int member_storev(int memberid, const DataSubset& subset)   = 0;
+  virtual int member_istore(
+    int memberid, const DataSubset& subset, Fenix_Request* req
+  ) = 0;
+  virtual int member_istorev(
+    int memberid, const DataSubset& subset, Fenix_Request* req
+  )                                          = 0;
+  virtual int commit()                       = 0;
+  virtual int snapshot_delete(int timestamp) = 0;
+  virtual int barrier()                      = 0;
+  virtual int member_restore(
+    int member_id, void* target_bugger, int max, int timestamp,
+    DataSubset& data_found
+  ) = 0;
+  virtual int member_lrestore(
+    int member_id, void* target_bugger, int max, int timestamp,
+    DataSubset& data_found
+  ) = 0;
+  virtual int member_restore_from_rank(
+    int member_id, void* target_bugger, int max, int timestamp, int source_rank
+  )                                                                  = 0;
+  virtual int get_number_of_snapshots(int* num)                      = 0;
+  virtual int get_snapshot_at_position(int position, int* timestamp) = 0;
+  virtual std::vector<int> get_snapshots()                           = 0;
+  virtual int reinit(int* flag)                                      = 0;
+  virtual int member_get_attribute(
+    fenix_member_entry_t* mentry, int name, void* value, int* flag,
+    int sourcerank
+  ) = 0;
+  virtual int member_set_attribute(
+    fenix_member_entry_t* mentry, int name, void* value, int* flag
+  ) = 0;
 };
 
 typedef struct __fenix_data_recovery {
-    size_t count;
-    size_t total_size;
-    fenix::data::fenix_group_t **group;
+  size_t count;
+  size_t total_size;
+  fenix::data::fenix_group_t** group;
 } fenix_data_recovery_t;
 
 typedef struct __group_entry_packet {
-    int groupid;
-    int timestamp;
-    int depth;
-    int rank_separation;
+  int groupid;
+  int timestamp;
+  int depth;
+  int rank_separation;
 } fenix_group_entry_packet_t;
 
-fenix_data_recovery_t * __fenix_data_recovery_init();
+fenix_data_recovery_t* __fenix_data_recovery_init();
 
 int __fenix_data_recovery_remove_group(int groupid);
-void __fenix_data_recovery_destroy( fenix_data_recovery_t *fx_data_recovery );
+void __fenix_data_recovery_destroy(fenix_data_recovery_t* fx_data_recovery);
 
-void __fenix_ensure_data_recovery_capacity( fenix_data_recovery_t *dr);
+void __fenix_ensure_data_recovery_capacity(fenix_data_recovery_t* dr);
 
-int __fenix_search_groupid( int key, fenix_data_recovery_t *dr);
+int __fenix_search_groupid(int key, fenix_data_recovery_t* dr);
 
-int __fenix_find_next_group_position( fenix_data_recovery_t *dr );
+int __fenix_find_next_group_position(fenix_data_recovery_t* dr);
 
 fenix_group_t* search_group(int id);
 fenix_group_t* find_group(
-    int id, std::source_location loc = std::source_location::current()
+  int id, std::source_location loc = std::source_location::current()
 );
 
 } //end namespace fenix::data

--- a/include/fenix_data_member.hpp
+++ b/include/fenix_data_member.hpp
@@ -62,22 +62,22 @@ namespace fenix::data {
 struct fenix_group_t;
 
 struct fenix_member_entry_packet_t {
-    int memberid;
-    int datatype_size;
-    int current_count;
+  int memberid;
+  int datatype_size;
+  int current_count;
 };
 
 struct fenix_member_entry_t {
-    fenix_member_entry_t() = default;
-    fenix_member_entry_t(int id, void* data, int count, MPI_Datatype datatype);
-    fenix_member_entry_t(int id, void* data, int count, int datatype_size);
+  fenix_member_entry_t() = default;
+  fenix_member_entry_t(int id, void* data, int count, MPI_Datatype datatype);
+  fenix_member_entry_t(int id, void* data, int count, int datatype_size);
 
-    fenix_member_entry_packet_t to_packet();
+  fenix_member_entry_packet_t to_packet();
 
-    int memberid = -1;
-    char *user_data = nullptr;
-    int current_count;
-    int datatype_size;
+  int memberid    = -1;
+  char* user_data = nullptr;
+  int current_count;
+  int datatype_size;
 };
 
 } // namespace fenix::data

--- a/include/fenix_data_subset.hpp
+++ b/include/fenix_data_subset.hpp
@@ -73,165 +73,169 @@ namespace detail {
 struct DataRegionIterator;
 
 struct DataRegion {
-    static constexpr size_t MAX = std::numeric_limits<size_t>::max();
+  static constexpr size_t MAX = std::numeric_limits<size_t>::max();
 
-    DataRegion(std::pair<size_t, size_t> b)
-        : DataRegion(b, 0, MAX) { };
-    DataRegion(std::pair<size_t, size_t> b, size_t m_reps, size_t m_stride)
-        : start(b.first),
-          end((b.second!=MAX && b.second+1==b.first+m_stride) ?
-                  b.second+m_reps*m_stride : b.second),
-          reps((b.second==MAX || b.second+1==b.first+m_stride) ? 0 : m_reps),
-          stride(reps == 0 ? MAX : m_stride)
-    {
-        fenix_assert(start <= end);
-        fenix_assert(stride != MAX || reps == 0);
-        fenix_assert(reps == 0 || start+stride > end);
-    };
+  DataRegion(std::pair<size_t, size_t> b) : DataRegion(b, 0, MAX) {};
+  DataRegion(std::pair<size_t, size_t> b, size_t m_reps, size_t m_stride)
+    : start(b.first),
+      end(
+        (b.second != MAX && b.second + 1 == b.first + m_stride)
+          ? b.second + m_reps * m_stride : b.second
+      ),
+      reps(
+        (b.second == MAX || b.second + 1 == b.first + m_stride) ? 0 : m_reps
+      ),
+      stride(reps == 0 ? MAX : m_stride) {
+    fenix_assert(start <= end);
+    fenix_assert(stride != MAX || reps == 0);
+    fenix_assert(reps == 0 || start + stride > end);
+  };
 
-    //Overall range of this region.
-    std::pair<size_t, size_t> range() const;
+  //Overall range of this region.
+  std::pair<size_t, size_t> range() const;
 
-    //Count of elements contained in this region
-    size_t count() const;
+  //Count of elements contained in this region
+  size_t count() const;
 
-    bool operator==(const DataRegion& other) const;
-    bool operator!=(const DataRegion& other) const;
+  bool operator==(const DataRegion& other) const;
+  bool operator!=(const DataRegion& other) const;
 
-    //Order based on start
-    bool operator<(const DataRegion& other) const;
+  //Order based on start
+  bool operator<(const DataRegion& other) const;
 
-    //Return true if these regions intersect
-    bool operator&&(const DataRegion& other) const;
+  //Return true if these regions intersect
+  bool operator&&(const DataRegion& other) const;
 
-    //Returns intersection of two regions. Not defined when both regions are strided.
-    std::set<DataRegion> operator&(const DataRegion& other) const;
-    
-    //This region w/o the overlap with other
-    std::set<DataRegion> operator-(const DataRegion& other) const;
+  //Returns intersection of two regions. Not defined when both regions are
+  //strided.
+  std::set<DataRegion> operator&(const DataRegion& other) const;
 
-    //Get a region that is a single repetition of this one's, with bounds check
-    DataRegion get_rep(size_t n) const;
-    //As above, but multiple repetitions
-    DataRegion get_reps(size_t first, size_t last) const;
+  //This region w/o the overlap with other
+  std::set<DataRegion> operator-(const DataRegion& other) const;
 
-    //For a strided region, returns region between repetitions
-    //Undefined for an unstrided region.
-    DataRegion inverted() const;
+  //Get a region that is a single repetition of this one's, with bounds check
+  DataRegion get_rep(size_t n) const;
+  //As above, but multiple repetitions
+  DataRegion get_reps(size_t first, size_t last) const;
 
-    std::optional<DataRegion> try_merge(const DataRegion& other) const;
+  //For a strided region, returns region between repetitions
+  //Undefined for an unstrided region.
+  DataRegion inverted() const;
 
-    std::string str() const;
+  std::optional<DataRegion> try_merge(const DataRegion& other) const;
 
-    //Inclusive region bounds.
-    size_t start, end;
+  std::string str() const;
 
-    //Number of times to repeat this after the first
-    size_t reps;
+  //Inclusive region bounds.
+  size_t start, end;
 
-    //Distance between starts of each repetition
-    size_t stride;
+  //Number of times to repeat this after the first
+  size_t reps;
+
+  //Distance between starts of each repetition
+  size_t stride;
 };
 } // namespace detail
 
 struct DataSubset {
-    static constexpr size_t MAX = detail::DataRegion::MAX;
+  static constexpr size_t MAX = detail::DataRegion::MAX;
 
-    enum SubsetType {
-        BasicSubset,
-        PrestagedSubset,
-    };
+  enum SubsetType {
+    BasicSubset,
+    PrestagedSubset,
+  };
 
-    //DataSubset(const DataSubset&) = default;
-    //DataSubset(DataSubset&&) = default;
-    //Empty
-    DataSubset() = default;
-    //[0, end]
-    explicit DataSubset(size_t end);
-    //[bounds.first, bounds.second]
-    DataSubset(std::pair<size_t, size_t> bounds);
-    //[b.first, b.second], ..., [b.first+stride*(n-1), b.second+stride*(n-1)]
-    DataSubset(std::pair<size_t, size_t> b, size_t n, size_t stride);
-    //[bounds[0].first, bounds[0].second], ...
-    DataSubset(std::vector<std::pair<size_t, size_t>> bounds);
-    //[first[0], second[0]], ... [first[n-1], second[n-1]]
-    DataSubset(int n, int* first, int* second);
-    //Merge two subsets
-    DataSubset(const DataSubset& a, const DataSubset& b);
-    //Create from serialized subset object
-    DataSubset(const DataBuffer& buf);
-    explicit DataSubset(SubsetType special_type) : type(special_type) { };
+  //DataSubset(const DataSubset&) = default;
+  //DataSubset(DataSubset&&) = default;
+  //Empty
+  DataSubset() = default;
+  //[0, end]
+  explicit DataSubset(size_t end);
+  //[bounds.first, bounds.second]
+  DataSubset(std::pair<size_t, size_t> bounds);
+  //[b.first, b.second], ..., [b.first+stride*(n-1), b.second+stride*(n-1)]
+  DataSubset(std::pair<size_t, size_t> b, size_t n, size_t stride);
+  //[bounds[0].first, bounds[0].second], ...
+  DataSubset(std::vector<std::pair<size_t, size_t>> bounds);
+  //[first[0], second[0]], ... [first[n-1], second[n-1]]
+  DataSubset(int n, int* first, int* second);
+  //Merge two subsets
+  DataSubset(const DataSubset& a, const DataSubset& b);
+  //Create from serialized subset object
+  DataSubset(const DataBuffer& buf);
+  explicit DataSubset(SubsetType special_type) : type(special_type) {};
 
-    DataSubset operator+(const DataSubset& other) const;
-    DataSubset& operator+=(const DataSubset& other);
-    
-    DataSubset operator+(const Fenix_Data_subset& other) const;
-    DataSubset& operator+=(const Fenix_Data_subset& other);
+  DataSubset operator+(const DataSubset& other) const;
+  DataSubset& operator+=(const DataSubset& other);
 
-    DataSubset operator-(const DataSubset& other) const;
-    bool operator==(const DataSubset& other) const;
-    bool operator!=(const DataSubset& other) const;
+  DataSubset operator+(const Fenix_Data_subset& other) const;
+  DataSubset& operator+=(const Fenix_Data_subset& other);
 
-    bool empty() const;
+  DataSubset operator-(const DataSubset& other) const;
+  bool operator==(const DataSubset& other) const;
+  bool operator!=(const DataSubset& other) const;
 
-    //Overall range of this subset
-    std::pair<size_t, size_t> range() const;
-    //Equivalent to range().first and range().second, possibly more performant
-    size_t start() const;
-    size_t end() const;
+  bool empty() const;
 
-    //Count of elements in this subset from [0, max_index]
-    //Returns 0 if max_index==end()==MAX
-    size_t count(size_t max_index) const;
+  //Overall range of this subset
+  std::pair<size_t, size_t> range() const;
+  //Equivalent to range().first and range().second, possibly more performant
+  size_t start() const;
+  size_t end() const;
 
-    //Count of elements in this subset if it were full [0, end()]
-    //Returns 0 if end()==MAX
-    size_t max_count() const;
+  //Count of elements in this subset from [0, max_index]
+  //Returns 0 if max_index==end()==MAX
+  size_t count(size_t max_index) const;
 
-    //Serialize this subset object into buf
-    //Will resize buf to fit exactly.
-    void serialize(DataBuffer& buf) const;
-   
-    //Will reset dst to fit
-    void serialize_data(
-        size_t elm_size, const DataBuffer& src, DataBuffer& dst
-    ) const;
-    //If dst.size()==0, will resize dst to fit
-    void deserialize_data(
-        size_t elm_size, const DataBuffer& src, DataBuffer& dst
-    ) const;
+  //Count of elements in this subset if it were full [0, end()]
+  //Returns 0 if end()==MAX
+  size_t max_count() const;
 
-    //If src_len == 0, will assume src is a large as needed
-    //Will resize dst if too small
-    void copy_data(
-        const size_t elm_size, const size_t src_len, const char* src, DataBuffer& dst
-    ) const;
-    //If dst_len == 0, will assume dst is as large as needed
-    void copy_data(
-        const size_t elm_size, const DataBuffer& src, const size_t dst_len,
-        char* dst
-    ) const;
-    
-    //Whether this subset includes the element at index idx
-    bool includes(size_t idx) const;
-    //Whether this subset includes the entire range [0, end] without gaps
-    bool includes_all(size_t end) const;
+  //Serialize this subset object into buf
+  //Will resize buf to fit exactly.
+  void serialize(DataBuffer& buf) const;
 
-    //Return equivalent of regions & [0, max_index]
-    std::set<detail::DataRegion> bounded_regions(size_t max_index) const;
-    //As above, but regions & [start, end]
-    std::set<detail::DataRegion> bounded_regions(size_t start, size_t end) const;
+  //Will reset dst to fit
+  void serialize_data(
+    size_t elm_size, const DataBuffer& src, DataBuffer& dst
+  ) const;
+  //If dst.size()==0, will resize dst to fit
+  void deserialize_data(
+    size_t elm_size, const DataBuffer& src, DataBuffer& dst
+  ) const;
 
-    std::string str() const;
+  //If src_len == 0, will assume src is a large as needed
+  //Will resize dst if too small
+  void copy_data(
+    const size_t elm_size, const size_t src_len, const char* src,
+    DataBuffer& dst
+  ) const;
+  //If dst_len == 0, will assume dst is as large as needed
+  void copy_data(
+    const size_t elm_size, const DataBuffer& src, const size_t dst_len,
+    char* dst
+  ) const;
 
-    //Individual data regions in this subset
-    std::set<detail::DataRegion> regions;
+  //Whether this subset includes the element at index idx
+  bool includes(size_t idx) const;
+  //Whether this subset includes the entire range [0, end] without gaps
+  bool includes_all(size_t end) const;
 
-    SubsetType type = BasicSubset;
+  //Return equivalent of regions & [0, max_index]
+  std::set<detail::DataRegion> bounded_regions(size_t max_index) const;
+  //As above, but regions & [start, end]
+  std::set<detail::DataRegion> bounded_regions(size_t start, size_t end) const;
 
-  private:
-    //merge immediately adjacent regions to simplify
-    void merge_regions();
+  std::string str() const;
+
+  //Individual data regions in this subset
+  std::set<detail::DataRegion> regions;
+
+  SubsetType type = BasicSubset;
+
+ private:
+  //merge immediately adjacent regions to simplify
+  void merge_regions();
 };
 } // namespace fenix
 #endif // __FENIX_DATA_SUBSET_HPP_

--- a/include/fenix_exception.hpp
+++ b/include/fenix_exception.hpp
@@ -93,8 +93,8 @@ struct RuntimeException : public std::exception {
 
   // file:line function error_string
   std::string to_string(int depth = 0) const noexcept {
-    std::string_view f = location.file_name();
-    std::string l = std::to_string(location.line());
+    std::string_view f  = location.file_name();
+    std::string l       = std::to_string(location.line());
     std::string_view fn = location.function_name();
 
     std::string ret;
@@ -102,9 +102,9 @@ struct RuntimeException : public std::exception {
       3 + depth * 2 + f.size() + l.size() + fn.size() + error_string.size()
     );
     ret.assign(" ", depth * 2);
-    ret += f;  ret += ":";
-    ret += l;  ret += " ";
-    ret += fn; ret += " ";
+    (ret += f) += ":";
+    (ret += l) += " ";
+    (ret += fn) += " ";
     ret += error_string;
     return ret;
   }

--- a/include/fenix_init.h
+++ b/include/fenix_init.h
@@ -64,8 +64,9 @@
 extern "C" {
 #endif
 
-int __fenix_preinit(int *, MPI_Comm, MPI_Comm *, int *, char ***, int, int *, jmp_buf *);
-
+int __fenix_preinit(
+  int*, MPI_Comm, MPI_Comm*, int*, char***, int, int*, jmp_buf*
+);
 
 void __fenix_postinit();
 

--- a/include/fenix_util.hpp
+++ b/include/fenix_util.hpp
@@ -114,15 +114,13 @@ struct ScopedIgnoreAndReturn {
 };
 
 struct ScopedActiveMlog {
-  ScopedActiveMlog(int id) : old_mlog(mlog::active()) {
-    mlog::activate(id);
-  }
+  ScopedActiveMlog(int id) : old_mlog(mlog::active()) { mlog::activate(id); }
   ~ScopedActiveMlog() {
     if (fenix::initialized()) mlog::activate(old_mlog);
   }
   const int old_mlog;
-  const bool old_inline_recovery =
-    old_mlog != FENIX_MLOG_NONE && get_option(MLOG_RECOVERY_MODE) != MANUAL &&
+  const bool old_inline_recovery = old_mlog != FENIX_MLOG_NONE &&
+    get_option(MLOG_RECOVERY_MODE) != MANUAL &&
     get_option(RECOVERY_MODE) != IGNORE;
 };
 

--- a/src/fenix_data_group.cpp
+++ b/src/fenix_data_group.cpp
@@ -66,46 +66,48 @@
 
 namespace fenix::data {
 
-fenix_group_t* search_group(int id){
+fenix_group_t* search_group(int id) {
   auto dr = fenix_rt.data_recovery;
-  for(int i = 0; i < dr->count; i++){
+  for (int i = 0; i < dr->count; i++) {
     auto group = dr->group[i];
-    if(dr->group[i]->groupid == id){
+    if (dr->group[i]->groupid == id) {
       return dr->group[i];
     }
   }
   return nullptr;
 }
 
-fenix_group_t* find_group(int id, std::source_location loc){
+fenix_group_t* find_group(int id, std::source_location loc) {
   auto group = search_group(id);
-  if(!group) FENIX_THROW_FROM(FENIX_ERROR_INVALID_GROUPID, loc);
+  if (!group) FENIX_THROW_FROM(FENIX_ERROR_INVALID_GROUPID, loc);
   return group;
 }
 
 fenix_group_t::fenix_group_t(
   int m_groupid, MPI_Comm m_comm, int m_timestart, int m_depth, int m_policy
 ) {
-  groupid = m_groupid;
-  comm = m_comm;
-  comm_size = util::comm_size(comm);
+  groupid      = m_groupid;
+  comm         = m_comm;
+  comm_size    = util::comm_size(comm);
   current_rank = util::comm_rank(comm);
-  timestart = m_timestart;
-  timestamp = -1;
-  depth = m_depth;
-  policy_name = m_policy;
+  timestart    = m_timestart;
+  timestamp    = -1;
+  depth        = m_depth;
+  policy_name  = m_policy;
 }
 
-fenix_member_entry_t* fenix_group_t::search_member(int id){
+fenix_member_entry_t* fenix_group_t::search_member(int id) {
   auto iter = members.find(id);
-  if(iter == members.end()) return nullptr;
+  if (iter == members.end()) return nullptr;
   assert(iter->first == iter->second.memberid);
   return &(iter->second);
 }
 
-fenix_member_entry_t* fenix_group_t::find_member(int id, std::source_location loc) {
+fenix_member_entry_t* fenix_group_t::find_member(
+  int id, std::source_location loc
+) {
   auto member = search_member(id);
-  if(!member) FENIX_THROW_FROM(FENIX_ERROR_INVALID_MEMBERID, loc);
+  if (!member) FENIX_THROW_FROM(FENIX_ERROR_INVALID_MEMBERID, loc);
   return member;
 }
 
@@ -113,7 +115,7 @@ int fenix_group_t::member_create(
   int id, void* data, int count, MPI_Datatype datatype
 ) {
   auto [iter, emplaced] = members.try_emplace(id, id, data, count, datatype);
-  if(!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
+  if (!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
   member_order.push_back(id);
   return this->member_create(&iter->second);
 }
@@ -123,15 +125,15 @@ int fenix_group_t::member_create(
 ) {
   auto [iter, emplaced] =
     members.try_emplace(id, id, data, count, datatype_size);
-  if(!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
+  if (!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
   member_order.push_back(id);
   return this->member_create(&iter->second);
 }
 
-int fenix_group_t::member_delete(int id){
+int fenix_group_t::member_delete(int id) {
   auto member = find_member(id);
-  int ret = this->member_delete(member);
-  if(ret == FENIX_SUCCESS) {
+  int ret     = this->member_delete(member);
+  if (ret == FENIX_SUCCESS) {
     members.erase(id);
     for (int i = 0; i < member_order.size(); i++) {
       if (member_order[i] == id) {
@@ -143,94 +145,104 @@ int fenix_group_t::member_delete(int id){
   return ret;
 }
 
-std::vector<int> fenix_group_t::get_member_ids(){ return member_order; }
+std::vector<int> fenix_group_t::get_member_ids() { return member_order; }
 
-fenix_data_recovery_t * __fenix_data_recovery_init() {
-  fenix_data_recovery_t *data_recovery = (fenix_data_recovery_t *)
-          s_calloc(1, sizeof(fenix_data_recovery_t));
+fenix_data_recovery_t* __fenix_data_recovery_init() {
+  fenix_data_recovery_t* data_recovery =
+    (fenix_data_recovery_t*)s_calloc(1, sizeof(fenix_data_recovery_t));
 
-  data_recovery->count = 0;
+  data_recovery->count      = 0;
   data_recovery->total_size = __FENIX_DEFAULT_GROUP_SIZE;
-  data_recovery->group = (fenix_group_t **) s_malloc(
-          __FENIX_DEFAULT_GROUP_SIZE * sizeof(fenix_group_t *));
+
+  data_recovery->group = (fenix_group_t**)s_malloc(
+    __FENIX_DEFAULT_GROUP_SIZE * sizeof(fenix_group_t*)
+  );
 
   if (fenix_rt.options.verbose == 41) {
-    verbose_print("c-rank: %d, role: %d, g-count: %zu, g-size: %zu\n",
-                    __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role, data_recovery->count,
-                  data_recovery->total_size);
+    verbose_print(
+      "c-rank: %d, role: %d, g-count: %zu, g-size: %zu\n",
+      __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role,
+      data_recovery->count, data_recovery->total_size
+    );
   }
 
   return data_recovery;
 }
 
+int __fenix_group_delete_direct(fenix_group_t* group) {
+  //We need this function to remove any allocated pointers
+  //that the fenix core adds before called the policy-specific
+  //group delete. This lets us update fenix core's group struct
+  //without having to potentially update the deletion process
+  //for each and every policy.
+  //
+  //We'll leave responsibility for calling
+  //__fenix_data_member_destroy()
+  //to the policy, as it may be using that as a reference for
+  //knowing how many members there are during its own deletion
+  //process.
 
-int __fenix_group_delete_direct(fenix_group_t* group){
-    //We need this function to remove any allocated pointers
-    //that the fenix core adds before called the policy-specific
-    //group delete. This lets us update fenix core's group struct
-    //without having to potentially update the deletion process 
-    //for each and every policy.
-    //
-    //We'll leave responsibility for calling 
-    //__fenix_data_member_destroy()
-    //to the policy, as it may be using that as a reference for
-    //knowing how many members there are during its own deletion
-    //process.
-    
-    return group->group_delete();
+  return group->group_delete();
 }
 
-int __fenix_data_recovery_remove_group(int groupid){
-    auto dr = fenix_rt.data_recovery;
+int __fenix_data_recovery_remove_group(int groupid) {
+  auto dr = fenix_rt.data_recovery;
 
-    bool found = false;
-    for(int i = 0; i < dr->count; i++){
-      if(dr->group[i] && dr->group[i]->groupid == groupid){
-        found = true;
-      }
-      if(found){
-        if(i < dr->count-1) dr->group[i] = dr->group[i+1];
-        else dr->group[i] = nullptr;
-      }
+  bool found = false;
+  for (int i = 0; i < dr->count; i++) {
+    if (dr->group[i] && dr->group[i]->groupid == groupid) {
+      found = true;
     }
-    if(!found) FENIX_THROW(FENIX_ERROR_INVALID_GROUPID);
-    dr->count--;
-
-    return FENIX_SUCCESS;
-}
-
-void __fenix_data_recovery_destroy( fenix_data_recovery_t *data_recovery )  {
-  int group_index;
-  for ( group_index = 0; group_index < data_recovery->count; group_index++ ) {
-      fenix_group_t* group = (data_recovery->group[group_index]);
-      
-      //Specific data policy function frees any data policy constructs
-      __fenix_group_delete_direct(group);
+    if (found) {
+      if (i < dr->count - 1) dr->group[i] = dr->group[i + 1];
+      else dr->group[i] = nullptr;
+    }
   }
-  free( data_recovery->group );
-  free( data_recovery );
+  if (!found) FENIX_THROW(FENIX_ERROR_INVALID_GROUPID);
+  dr->count--;
+
+  return FENIX_SUCCESS;
 }
 
-void __fenix_ensure_data_recovery_capacity(fenix_data_recovery_t* data_recovery) {
-  //If we're ensuring there is space for a new group, we need to check that count+1 is < size
-  if (data_recovery->count +1 >= data_recovery->total_size) {
-    int start_index = data_recovery->total_size;
-    data_recovery->group = (fenix_group_t **) s_realloc(data_recovery->group,
-                                                           (data_recovery->total_size * 2) *
-                                                           sizeof(fenix_group_t *));
+void __fenix_data_recovery_destroy(fenix_data_recovery_t* data_recovery) {
+  int group_index;
+  for (group_index = 0; group_index < data_recovery->count; group_index++) {
+    fenix_group_t* group = (data_recovery->group[group_index]);
+
+    //Specific data policy function frees any data policy constructs
+    __fenix_group_delete_direct(group);
+  }
+  free(data_recovery->group);
+  free(data_recovery);
+}
+
+void __fenix_ensure_data_recovery_capacity(
+  fenix_data_recovery_t* data_recovery
+) {
+  //If we're ensuring there is space for a new group, we need to check that
+  //count+1 is < size
+  if (data_recovery->count + 1 >= data_recovery->total_size) {
+    int start_index      = data_recovery->total_size;
+    data_recovery->group = (fenix_group_t**)s_realloc(
+      data_recovery->group,
+      (data_recovery->total_size * 2) * sizeof(fenix_group_t*)
+    );
     data_recovery->total_size = data_recovery->total_size * 2;
 
     if (fenix_rt.options.verbose == 51) {
-      verbose_print("g-count: %zu, g-size: %zu\n", data_recovery->count, data_recovery->total_size);
+      verbose_print(
+        "g-count: %zu, g-size: %zu\n", data_recovery->count,
+        data_recovery->total_size
+      );
     }
   }
 }
 
-int __fenix_search_groupid(int key, fenix_data_recovery_t *data_recovery) {
+int __fenix_search_groupid(int key, fenix_data_recovery_t* data_recovery) {
   int group_index, found = -1, index = -1;
-  for (group_index = 0;
-       (found != 1) && (group_index < data_recovery->count); group_index++) {
-    fenix_group_t *group = (data_recovery->group[group_index]);
+  for (group_index = 0; (found != 1) && (group_index < data_recovery->count);
+       group_index++) {
+    fenix_group_t* group = (data_recovery->group[group_index]);
     if (key == group->groupid) {
       index = group_index;
       found = 1;
@@ -239,7 +251,7 @@ int __fenix_search_groupid(int key, fenix_data_recovery_t *data_recovery) {
   return index;
 }
 
-int __fenix_find_next_group_position( fenix_data_recovery_t *data_recovery ) {
+int __fenix_find_next_group_position(fenix_data_recovery_t* data_recovery) {
   //Ensure that we have space.
   __fenix_ensure_data_recovery_capacity(data_recovery);
   return data_recovery->count;

--- a/src/fenix_data_member.cpp
+++ b/src/fenix_data_member.cpp
@@ -60,10 +60,9 @@
 
 namespace fenix::data {
 
-fenix_member_entry_packet_t
-fenix_member_entry_t::to_packet(){
+fenix_member_entry_packet_t fenix_member_entry_t::to_packet() {
   fenix_member_entry_packet_t to_ret;
-  to_ret.memberid = memberid;
+  to_ret.memberid      = memberid;
   to_ret.datatype_size = datatype_size;
   to_ret.current_count = current_count;
   return to_ret;
@@ -71,11 +70,13 @@ fenix_member_entry_t::to_packet(){
 
 fenix_member_entry_t::fenix_member_entry_t(
   int id, void* data, int count, MPI_Datatype datatype
-) : fenix_member_entry_t(id, data, count, __fenix_get_size(datatype)) { };
+)
+  : fenix_member_entry_t(id, data, count, __fenix_get_size(datatype)) {};
 
 fenix_member_entry_t::fenix_member_entry_t(
   int id, void* data, int count, int dsize
-) : memberid(id), user_data((char*)data), current_count(count),
-    datatype_size(dsize) { };
+)
+  : memberid(id), user_data((char*)data), current_count(count),
+    datatype_size(dsize) {};
 
 } //namespace fenix::data

--- a/src/fenix_data_policy.cpp
+++ b/src/fenix_data_policy.cpp
@@ -64,16 +64,17 @@
 namespace fenix::data {
 
 fenix_group_t* new_group(
-   int groupid, MPI_Comm comm, int timestart, int depth, int policy_name,
-   void* policy_value, int* flag
+  int groupid, MPI_Comm comm, int timestart, int depth, int policy_name,
+  void* policy_value, int* flag
 ) {
-   switch(policy_name){
-      case FENIX_DATA_POLICY_IN_MEMORY_RAID:
-         return new imr::Group(
-            groupid, comm, timestart, depth, (int*)policy_value, flag
-         );
-      default: FENIX_THROW(FENIX_ERROR_INVALID_POLICY_NAME);
-   }
+  switch (policy_name) {
+  case FENIX_DATA_POLICY_IN_MEMORY_RAID:
+    return new imr::Group(
+      groupid, comm, timestart, depth, (int*)policy_value, flag
+    );
+  default:
+    FENIX_THROW(FENIX_ERROR_INVALID_POLICY_NAME);
+  }
 }
 
 }

--- a/src/fenix_data_policy_in_memory_raid.cpp
+++ b/src/fenix_data_policy_in_memory_raid.cpp
@@ -88,857 +88,854 @@
 namespace fenix::data::imr {
 
 Entry::Entry(int size, int max_count)
-   : elm_size(size), elm_max_count(max_count) {
-   buf.reserve(size * max_count);
+  : elm_size(size), elm_max_count(max_count) {
+  buf.reserve(size * max_count);
 }
 
-Entry::Entry(Entry&& other){
-   *this = std::move(other);
+Entry::Entry(Entry&& other) { *this = std::move(other); }
+
+Entry& Entry::operator=(Entry&& other) {
+  timestamp = std::exchange(other.timestamp, -2);
+
+  region         = std::move(other.region);
+  partner_region = std::move(partner_region);
+  buf            = std::move(other.buf);
+  partner_buf    = std::move(other.partner_buf);
+  elm_size       = other.elm_size;
+  elm_max_count  = other.elm_max_count;
+  return *this;
 }
 
-Entry& Entry::operator=(Entry&& other){
-    timestamp = std::exchange(other.timestamp, -2);
+char* Entry::data() { return buf.data(); }
+void Entry::resize(int size) { buf.resize(size); }
+int Entry::size() { return buf.size(); }
 
-    region = std::move(other.region);
-    partner_region = std::move(partner_region);
-    buf = std::move(other.buf);
-    partner_buf = std::move(other.partner_buf);
-    elm_size = other.elm_size;
-    elm_max_count = other.elm_max_count;
-    return *this;
+char* Entry::partner_data() { return partner_buf.data(); }
+void Entry::partner_resize(int size) { partner_buf.resize(size); }
+int Entry::partner_size() { return partner_buf.size(); }
+
+void Entry::add_and_fit(const DataSubset& subset) {
+  region += subset;
+
+  int new_count = elm_max_count;
+  if (!new_count) region.max_count();
+  if (!new_count) new_count = subset.max_count();
+
+  int new_size = new_count * elm_size;
+  if (new_size > buf.size()) buf.resize(new_size);
 }
 
-char* Entry::data(){ return buf.data(); }
-void Entry::resize(int size){ buf.resize(size); }
-int Entry::size(){ return buf.size(); }
+void Entry::partner_add_and_fit(const DataSubset& subset) {
+  partner_region += subset;
 
-char* Entry::partner_data(){ return partner_buf.data(); }
-void Entry::partner_resize(int size){ partner_buf.resize(size); }
-int Entry::partner_size(){ return partner_buf.size(); }
+  int new_count = elm_max_count;
+  if (!new_count) partner_region.max_count();
+  if (!new_count) new_count = subset.max_count();
 
-void Entry::add_and_fit(const DataSubset& subset){
-   region += subset;
-
-   int new_count = elm_max_count; 
-   if(!new_count) region.max_count();
-   if(!new_count) new_count = subset.max_count();
-
-   int new_size = new_count*elm_size;
-   if(new_size > buf.size()) buf.resize(new_size);
+  int new_size = new_count * elm_size;
+  if (new_size > partner_buf.size()) partner_buf.resize(new_size);
 }
 
-void Entry::partner_add_and_fit(const DataSubset& subset){
-   partner_region += subset;
+void Entry::reset() {
+  timestamp = -2;
 
-   int new_count = elm_max_count;
-   if(!new_count) partner_region.max_count();
-   if(!new_count) new_count = subset.max_count();
+  buf.clear();
+  partner_buf.clear();
 
-   int new_size = new_count*elm_size;
-   if(new_size > partner_buf.size()) partner_buf.resize(new_size);
-}
-
-void Entry::reset(){
-   timestamp = -2;
-   
-   buf.clear();
-   partner_buf.clear();
-   
-   region = {};
-   partner_region = {};
+  region         = {};
+  partner_region = {};
 }
 
 Member::Member(fenix_member_entry_t& my_mentry, Group& my_group)
-   : mentry(my_mentry), group(my_group), send_buf(group.send_buf),
-     recv_buf(group.recv_buf)
-{
-   for(int i = 0; i < group.depth+2; i++){
-      entries.emplace_back(mentry.datatype_size, mentry.current_count);
-   }
+  : mentry(my_mentry), group(my_group), send_buf(group.send_buf),
+    recv_buf(group.recv_buf) {
+  for (int i = 0; i < group.depth + 2; i++) {
+    entries.emplace_back(mentry.datatype_size, mentry.current_count);
+  }
 }
 
 BuddyMember::BuddyMember(fenix_member_entry_t& my_mentry, Group& my_group)
-   : Member(my_mentry, my_group) {
-   for(auto& entry : entries)
-      entry.partner_resize(mentry.datatype_size*mentry.current_count);
+  : Member(my_mentry, my_group) {
+  for (auto& entry : entries)
+    entry.partner_resize(mentry.datatype_size * mentry.current_count);
 }
 
 ParityMember::ParityMember(fenix_member_entry_t& my_mentry, Group& my_group)
-   : Member(my_mentry, my_group) {
-   int data_len = (mentry.datatype_size*mentry.current_count);
-   int parity_len = data_len / (group.set_size-1);
+  : Member(my_mentry, my_group) {
+  int data_len   = (mentry.datatype_size * mentry.current_count);
+  int parity_len = data_len / (group.set_size - 1);
 
-   int remainder = data_len % (group.set_size-1);
-   if(remainder) remainder++;
-   if(remainder < group.set_rank) parity_len++;
+  int remainder = data_len % (group.set_size - 1);
+  if (remainder) remainder++;
+  if (remainder < group.set_rank) parity_len++;
 
-   for(auto& entry : entries)
-      entry.partner_resize(parity_len);
+  for (auto& entry : entries) entry.partner_resize(parity_len);
 }
 
-
-bool Member::snapshot_delete(int timestamp){
-   bool found = false;
-   for(int i = entries.size(); i >= 0; i--){
-      if(entries[i].timestamp == timestamp){
-         assert(!found);
-         found = true;
-         entries[i].reset();
-      }
-      //Move deleted snapshot to front
-      if(found && i > 0){
-         std::swap(entries[i], entries[i-1]);
-      }
-   }
-   return found;
+bool Member::snapshot_delete(int timestamp) {
+  bool found = false;
+  for (int i = entries.size(); i >= 0; i--) {
+    if (entries[i].timestamp == timestamp) {
+      assert(!found);
+      found = true;
+      entries[i].reset();
+    }
+    //Move deleted snapshot to front
+    if (found && i > 0) {
+      std::swap(entries[i], entries[i - 1]);
+    }
+  }
+  return found;
 }
 
-void Member::stage(const DataSubset& subset){
-   if (subset == SUBSET_PRESTAGED)
-      FENIX_THROW("Cannot stage FENIX_DATA_SUBSET_PRESTAGED");
+void Member::stage(const DataSubset& subset) {
+  if (subset == SUBSET_PRESTAGED)
+    FENIX_THROW("Cannot stage FENIX_DATA_SUBSET_PRESTAGED");
 
-   Entry& e = entries.back();
-   e.add_and_fit(subset);
-   subset.copy_data(e.elm_size, e.elm_max_count, mentry.user_data, e.buf);
+  Entry& e = entries.back();
+  e.add_and_fit(subset);
+  subset.copy_data(e.elm_size, e.elm_max_count, mentry.user_data, e.buf);
 }
 
-tasks::Task<int> Member::istorev(const DataSubset& subset){
-   if (subset == SUBSET_PRESTAGED) {
-      Entry& e = entries.back();
-      return this->istorev_impl(e.region);
-   } else {
-      stage(subset);
-      return this->istorev_impl(subset);
-   }
+tasks::Task<int> Member::istorev(const DataSubset& subset) {
+  if (subset == SUBSET_PRESTAGED) {
+    Entry& e = entries.back();
+    return this->istorev_impl(e.region);
+  } else {
+    stage(subset);
+    return this->istorev_impl(subset);
+  }
 }
 
 tasks::Task<int> BuddyMember::exch(
-   const DataSubset& subset, const DataSubset& partner_subset
-){
-   const int rank = group.set_rank;
-   const int left = rank == 0 ? group.set_size-1 : rank-1;
-   const int right = rank == group.set_size-1 ? 0 : rank+1;
+  const DataSubset& subset, const DataSubset& partner_subset
+) {
+  const int rank  = group.set_rank;
+  const int left  = rank == 0 ? group.set_size - 1 : rank - 1;
+  const int right = rank == group.set_size - 1 ? 0 : rank + 1;
 
-   Entry& e = entries.back();
-   e.partner_add_and_fit(partner_subset);
+  Entry& e = entries.back();
+  e.partner_add_and_fit(partner_subset);
 
-   int recv_count = partner_subset.count(e.elm_max_count-1);
-   recv_buf.reset(e.elm_size*recv_count);
+  int recv_count = partner_subset.count(e.elm_max_count - 1);
+  recv_buf.reset(e.elm_size * recv_count);
 
-   subset.serialize_data(e.elm_size, e.buf, send_buf);
+  subset.serialize_data(e.elm_size, e.buf, send_buf);
 
-   co_await tasks::mpi::sendrecv(
-      send_buf.data(), send_buf.size(), MPI_BYTE, right, 0,
-      recv_buf.data(), recv_buf.size(), MPI_BYTE,  left, 0,
-      group.set_comm
-   );
- 
-   partner_subset.deserialize_data(
-      e.elm_size, recv_buf, e.partner_buf
-   );
-   co_return FENIX_SUCCESS;
+  co_await tasks::mpi::sendrecv(
+    send_buf.data(), send_buf.size(), MPI_BYTE, right, 0,
+    recv_buf.data(), recv_buf.size(), MPI_BYTE,  left, 0,
+    group.set_comm
+  );
+
+  partner_subset.deserialize_data(e.elm_size, recv_buf, e.partner_buf);
+  co_return FENIX_SUCCESS;
 }
 
-tasks::Task<int> BuddyMember::istorev_impl(const DataSubset& subset){
-   //My partner ranks (within set_comm)
-   const int rank = group.set_rank;
-   const int left = rank == 0 ? group.set_size-1 : rank-1;
-   const int right = rank == group.set_size-1 ? 0 : rank+1;
+tasks::Task<int> BuddyMember::istorev_impl(const DataSubset& subset) {
+  //My partner ranks (within set_comm)
+  const int rank  = group.set_rank;
+  const int left  = rank == 0 ? group.set_size - 1 : rank - 1;
+  const int right = rank == group.set_size - 1 ? 0 : rank + 1;
 
-   DataBuffer send_buf, recv_buf;
-   subset.serialize(send_buf);
+  DataBuffer send_buf, recv_buf;
+  subset.serialize(send_buf);
 
-   for(int i = 0; i < group.set_size; i++){
-      if(i == rank) co_await send_buf.send(right, 0, group.set_comm);
-      if(i == left) co_await recv_buf.recv_unknown(left, 0, group.set_comm);
-   }
+  for (int i = 0; i < group.set_size; i++) {
+    if (i == rank) co_await send_buf.send(right, 0, group.set_comm);
+    if (i == left) co_await recv_buf.recv_unknown(left, 0, group.set_comm);
+  }
 
-   co_return co_await exch(subset, DataSubset(recv_buf));
+  co_return co_await exch(subset, DataSubset(recv_buf));
 }
 
-tasks::Task<int> Member::istore(const DataSubset& subset){
-   if (subset == SUBSET_PRESTAGED) {
-      Entry& e = entries.back();
-      return this->istore_impl(e.region);
-   } else {
-      stage(subset);
-      return this->istore_impl(subset);
-   }
+tasks::Task<int> Member::istore(const DataSubset& subset) {
+  if (subset == SUBSET_PRESTAGED) {
+    Entry& e = entries.back();
+    return this->istore_impl(e.region);
+  } else {
+    stage(subset);
+    return this->istore_impl(subset);
+  }
 }
 
-tasks::Task<int> BuddyMember::istore_impl(const DataSubset& subset){
-   return exch(subset, subset);
+tasks::Task<int> BuddyMember::istore_impl(const DataSubset& subset) {
+  return exch(subset, subset);
 }
 
-tasks::Task<int> ParityMember::istore_impl(const DataSubset& subset){
-   Entry& entry = entries.back();
+tasks::Task<int> ParityMember::istore_impl(const DataSubset& subset) {
+  Entry& entry = entries.back();
 
-   int parity_size = entry.size()/(group.set_size - 1);
-   int remainder = entry.size()%(group.set_size - 1);
+  int parity_size = entry.size() / (group.set_size - 1);
+  int remainder   = entry.size() % (group.set_size - 1);
 
-   //If we have any remainder, treat as if we have one more, since a rank
-   //storing a larger parity block wasn't able to store a larger data block, so
-   //all such ranks need one extra larger data block.
-   if(remainder) remainder++;
+  //If we have any remainder, treat as if we have one more, since a rank
+  //storing a larger parity block wasn't able to store a larger data block, so
+  //all such ranks need one extra larger data block.
+  if (remainder) remainder++;
 
-   int m_parity_size = parity_size;
-   if(group.set_rank<remainder) m_parity_size++;
-   entry.partner_resize(m_parity_size);
+  int m_parity_size = parity_size;
+  if (group.set_rank < remainder) m_parity_size++;
+  entry.partner_resize(m_parity_size);
 
-   //Zero out the parity data before computing, so old data doesn't contribute
-   std::memset(entry.partner_data(), 0, entry.partner_size());
-   
-   int offset = 0;
-   for(int i = 0; i < group.set_size; i++){
-      int len = i < remainder ? parity_size + 1 : parity_size;
+  //Zero out the parity data before computing, so old data doesn't contribute
+  std::memset(entry.partner_data(), 0, entry.partner_size());
 
-      char* input;
-      if(group.set_rank == i){
-         //The rank storing this parity region contributes the all zero input
-         //as a way of not contributing
-         input = entry.partner_data();
-      } else {
-         if(offset+len > entry.size()){
-            //Since we pretend to have an extra remainder if there is any
-            assert(remainder);
-            assert(group.set_rank >= remainder);
-            assert(offset+len == entry.size()+1);
-            offset--;
-         }
-         input = entry.data()+offset;
-         offset += len;
+  int offset = 0;
+  for (int i = 0; i < group.set_size; i++) {
+    int len = i < remainder ? parity_size + 1 : parity_size;
+
+    char* input;
+    if (group.set_rank == i) {
+      //The rank storing this parity region contributes the all zero input
+      //as a way of not contributing
+      input = entry.partner_data();
+    } else {
+      if (offset + len > entry.size()) {
+        //Since we pretend to have an extra remainder if there is any
+        assert(remainder);
+        assert(group.set_rank >= remainder);
+        assert(offset + len == entry.size() + 1);
+        offset--;
       }
+      input = entry.data() + offset;
+      offset += len;
+    }
 
-      co_await tasks::mpi::reduce(
-         MPI_IN_PLACE, input, len, MPI_BYTE, MPI_BXOR, i, group.set_comm
-      );
-   }
+    co_await tasks::mpi::reduce(
+      MPI_IN_PLACE, input, len, MPI_BYTE, MPI_BXOR, i, group.set_comm
+    );
+  }
 
-   assert(offset == entry.size());
-   co_return FENIX_SUCCESS;
+  assert(offset == entry.size());
+  co_return FENIX_SUCCESS;
 }
 
-void Member::commit(int timestamp){
-   entries.back().timestamp = timestamp;
+void Member::commit(int timestamp) {
+  entries.back().timestamp = timestamp;
 
-   Entry oldest = std::move(entries.front());
-   entries.pop_front();
-   oldest.reset();
+  Entry oldest = std::move(entries.front());
+  entries.pop_front();
+  oldest.reset();
 
-   entries.push_back(std::move(oldest));
+  entries.push_back(std::move(oldest));
 }
 
-int Member::restore(){
-   //First clear out any snapshots that we have but the group doesn't.
-   auto begin = group.timestamps.begin();
-   const auto end = group.timestamps.end();
-   for(int entry = 0; entry < entries.size()-1; entry++){
-      if(entries[entry].timestamp == -2) continue;
-      begin = std::lower_bound(begin, end, entries[entry].timestamp);
-      if(begin == end || *begin != entries[entry].timestamp)
-         entries[entry].reset();
-   }
+int Member::restore() {
+  //First clear out any snapshots that we have but the group doesn't.
+  auto begin     = group.timestamps.begin();
+  const auto end = group.timestamps.end();
+  for (int entry = 0; entry < entries.size() - 1; entry++) {
+    if (entries[entry].timestamp == -2) continue;
+    begin = std::lower_bound(begin, end, entries[entry].timestamp);
+    if (begin == end || *begin != entries[entry].timestamp)
+      entries[entry].reset();
+  }
 
-   //Now make sure snapshots align with group's timestamps
-   for(int snapshot = 1; snapshot <= group.timestamps.size(); snapshot++){
-      int timestamp = group.timestamps[group.timestamps.size()-snapshot];
-      int target = entries.size()-snapshot-1;
-      int actual;
-      for(actual = target; actual >= 0; actual--){
-         if(entries[actual].timestamp == timestamp) break;
+  //Now make sure snapshots align with group's timestamps
+  for (int snapshot = 1; snapshot <= group.timestamps.size(); snapshot++) {
+    int timestamp = group.timestamps[group.timestamps.size() - snapshot];
+    int target    = entries.size() - snapshot - 1;
+    int actual;
+    for (actual = target; actual >= 0; actual--) {
+      if (entries[actual].timestamp == timestamp) break;
+    }
+    if (actual == target) continue;
+    if (actual != -1) {
+      std::swap(entries[actual], entries[target]);
+    } else {
+      int free = -1;
+      for (int i = 0; i <= target && free == -1; i++) {
+        if (entries[i].timestamp == -2) free = i;
       }
-      if(actual == target) continue;
-      if(actual != -1) {
-         std::swap(entries[actual], entries[target]);
-      } else {
-         int free = -1;
-         for(int i = 0; i <= target && free == -1; i++){
-            if(entries[i].timestamp == -2) free = i;
-         }
-         assert(free != -1);
-         std::swap(entries[free], entries[target]);
-      }
-   }
+      assert(free != -1);
+      std::swap(entries[free], entries[target]);
+    }
+  }
 
-   //Reset the current store buffer entry
-   entries.back().reset();
-   return this->restore_impl();
+  //Reset the current store buffer entry
+  entries.back().reset();
+  return this->restore_impl();
 }
 
-int BuddyMember::restore_impl(){
-   //My partner ranks (within set_comm)
-   const int rank = group.set_rank;
-   const int left = rank == 0 ? group.set_size-1 : rank-1;
-   const int right = rank == group.set_size-1 ? 0 : rank+1;
+int BuddyMember::restore_impl() {
+  //My partner ranks (within set_comm)
+  const int rank  = group.set_rank;
+  const int left  = rank == 0 ? group.set_size - 1 : rank - 1;
+  const int right = rank == group.set_size - 1 ? 0 : rank + 1;
 
-   //Data on which partners have found each snapshot
-   int found[3];
-   int& found_here = found[rank];
-   int& found_left = found[left];
-   int& found_right = found[right];
+  //Data on which partners have found each snapshot
+  int found[3];
+  int& found_here  = found[rank];
+  int& found_left  = found[left];
+  int& found_right = found[right];
 
-   auto e = entries.rbegin()+1;
-   auto ts = group.timestamps.rbegin();
-   for(; ts != group.timestamps.rend(); ts++, e++){
-      fenix_assert(e->timestamp == -2 || e->timestamp == *ts);
+  auto e  = entries.rbegin() + 1;
+  auto ts = group.timestamps.rbegin();
+  for (; ts != group.timestamps.rend(); ts++, e++) {
+    fenix_assert(e->timestamp == -2 || e->timestamp == *ts);
 
-      found_here = e->timestamp != -2;
-      MPI_Allgather(
-         MPI_IN_PLACE, 1, MPI_INT, found, 1, MPI_INT, group.set_comm
-      );
+    found_here = e->timestamp != -2;
+    MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT, found, 1, MPI_INT, group.set_comm);
 
-      int n_missing = 0;
-      for(int i = 0; i < group.set_size; i++) if(!found[i]) n_missing++;
-      if(n_missing == 0)
-         continue;
-      else if(n_missing > 1){
-         if(group.set_rank == 0)
-            debug_print(
-               "WARNING Fenix_Data_member_restore: %s member %d timestamp %d unrecoverable",
-               group.str().c_str(), id, *ts
-            );
-         continue;
+    int n_missing = 0;
+    for (int i = 0; i < group.set_size; i++) n_missing += found[i] ? 0 : 1;
+    if (n_missing == 0) continue;
+    if (n_missing > 1) {
+      if (group.set_rank == 0) {
+        debug_print(
+          "WARNING Fenix_Data_member_restore: %s member %d timestamp %d "
+          "unrecoverable", group.str().c_str(), id, *ts
+        );
       }
-     
-      if(!found_here){
-         //Fetch my data region from right partner
-         recv_buf.recv_unknown(right, 0, group.set_comm).wait();
-         e->add_and_fit({recv_buf});
-         //Fetch my data
-         int m_count = e->region.count(e->elm_max_count-1);
-         recv_buf.recv(m_count*e->elm_size, right, 0, group.set_comm).wait();
-         e->region.deserialize_data(e->elm_size, recv_buf, e->buf);
+      continue;
+    }
 
-         //Fetch left partner's region
-         recv_buf.recv_unknown(left, 0, group.set_comm).wait();
-         e->partner_add_and_fit({recv_buf});
-         //Fetch data
-         int p_count = e->partner_region.count(e->elm_max_count-1);
-         recv_buf.recv(p_count*e->elm_size, left, 0, group.set_comm).wait();
-         e->partner_region.deserialize_data(
-            e->elm_size, recv_buf, e->partner_buf
-         );
+    if (!found_here) {
+      //Fetch my data region from right partner
+      recv_buf.recv_unknown(right, 0, group.set_comm).wait();
+      e->add_and_fit({recv_buf});
+      //Fetch my data
+      int m_count = e->region.count(e->elm_max_count - 1);
+      recv_buf.recv(m_count * e->elm_size, right, 0, group.set_comm).wait();
+      e->region.deserialize_data(e->elm_size, recv_buf, e->buf);
 
-         //Only update timestamp after all other data updated, to indicate
-         //recovery of this snapshot completed
-         e->timestamp = *ts;
-      }
-      if(!found_left){
-         //Send partner's data region
-         e->partner_region.serialize(send_buf);
-         send_buf.send(left, 0, group.set_comm).wait();
-         //Send their data
-         e->partner_region.serialize_data(
-            e->elm_size, e->partner_buf, send_buf
-         );
-         send_buf.send(left, 0, group.set_comm).wait();
-      }
-      if(!found_right){
-         //Send my data region
-         e->region.serialize(send_buf);
-         send_buf.send(right, 0, group.set_comm).wait();
-         //Send my data
-         e->region.serialize_data(e->elm_size, e->buf, send_buf);
-         send_buf.send(right, 0, group.set_comm).wait();
-      }
-   }
-   return FENIX_SUCCESS;
-}
+      //Fetch left partner's region
+      recv_buf.recv_unknown(left, 0, group.set_comm).wait();
+      e->partner_add_and_fit({recv_buf});
+      //Fetch data
+      int p_count = e->partner_region.count(e->elm_max_count - 1);
+      recv_buf.recv(p_count * e->elm_size, left, 0, group.set_comm).wait();
+      e->partner_region.deserialize_data(e->elm_size, recv_buf, e->partner_buf);
 
-int ParityMember::restore_impl(){
-   //Data on which partners have found each snapshot
-   std::vector<int> found;
-   found.resize(group.set_size);
-   int found_here;
-
-   auto e = entries.rbegin()+1;
-   auto ts = group.timestamps.rbegin();
-   for(; ts != group.timestamps.rend(); ts++, e++){
-      fenix_assert(e->timestamp == -2 || e->timestamp == *ts);
-     
-      found_here = e->timestamp != -2;
-      MPI_Allgather(
-         &found_here, 1, MPI_INT, found.data(), 1, MPI_INT, group.set_comm
-      );
-
-      int recovering = -1;
-      for(int i = 0; i < group.set_size; i++){
-         if(found[i]) continue;
-         if(recovering != -1){
-            if(group.set_rank == 0)
-               debug_print(
-                  "WARNING Fenix_Data_member_restore: %s member %d timestamp %d unrecoverable",
-                  group.str().c_str(), id, *ts
-               );
-            recovering = -1;
-            break;
-         } else {
-            recovering = i;
-         }
-      }
-      if(recovering == -1) continue;
-
-      int sender = recovering == 0 ? 1 : 0;
-      if(group.set_rank == sender){
-         e->region.serialize(send_buf);
-         send_buf.send(recovering, 0, group.set_comm).wait();
-      } else if(!found_here){
-         recv_buf.recv_unknown(sender, 0, group.set_comm).wait();
-         e->add_and_fit({recv_buf});
-      }
-
-      //Use the same logic as store, but recovering rank is always root and
-      //zeroes out the local data region before participating.
-      int parity_size = e->size()/(group.set_size - 1);
-      int remainder = e->size()%(group.set_size - 1);
-      if(remainder) remainder++;
-      int m_parity_size = parity_size;
-      if(group.set_rank<remainder) m_parity_size++;
-      e->partner_resize(m_parity_size);
-
-      if(!found_here){
-         std::memset(e->data(), 0, e->size());
-         std::memset(e->partner_data(), 0, e->partner_size());
-      }
-
-      int offset = 0;
-      for(int i = 0; i < group.set_size; i++){
-         int len = i < remainder ? parity_size + 1 : parity_size;
-         char* input;
-         if(group.set_rank == i){
-            input = e->partner_data();
-         } else {
-            if(offset+len > e->size()) offset--;
-            input = e->data()+offset;
-            offset += len;
-         }
-         MPI_Reduce(
-            MPI_IN_PLACE, input, len, MPI_BYTE, MPI_BXOR, recovering,
-            group.set_comm
-         );
-      }
-      assert(offset == e->size());
-
+      //Only update timestamp after all other data updated, to indicate
+      //recovery of this snapshot completed
       e->timestamp = *ts;
-   }
+    }
+    if (!found_left) {
+      //Send partner's data region
+      e->partner_region.serialize(send_buf);
+      send_buf.send(left, 0, group.set_comm).wait();
+      //Send their data
+      e->partner_region.serialize_data(e->elm_size, e->partner_buf, send_buf);
+      send_buf.send(left, 0, group.set_comm).wait();
+    }
+    if (!found_right) {
+      //Send my data region
+      e->region.serialize(send_buf);
+      send_buf.send(right, 0, group.set_comm).wait();
+      //Send my data
+      e->region.serialize_data(e->elm_size, e->buf, send_buf);
+      send_buf.send(right, 0, group.set_comm).wait();
+    }
+  }
+  return FENIX_SUCCESS;
+}
 
-   return FENIX_SUCCESS;
+int ParityMember::restore_impl() {
+  //Data on which partners have found each snapshot
+  std::vector<int> found;
+  found.resize(group.set_size);
+  int found_here;
+
+  auto e  = entries.rbegin() + 1;
+  auto ts = group.timestamps.rbegin();
+  for (; ts != group.timestamps.rend(); ts++, e++) {
+    fenix_assert(e->timestamp == -2 || e->timestamp == *ts);
+
+    found_here = e->timestamp != -2;
+    MPI_Allgather(
+      &found_here, 1, MPI_INT, found.data(), 1, MPI_INT, group.set_comm
+    );
+
+    int recovering = -1;
+    for (int i = 0; i < group.set_size; i++) {
+      if (found[i]) continue;
+      if (recovering != -1) {
+        if (group.set_rank == 0) {
+          debug_print(
+            "WARNING Fenix_Data_member_restore: %s member %d timestamp %d "
+            "unrecoverable", group.str().c_str(), id, *ts
+          );
+        }
+        recovering = -1;
+        break;
+      } else {
+        recovering = i;
+      }
+    }
+    if (recovering == -1) continue;
+
+    int sender = recovering == 0 ? 1 : 0;
+    if (group.set_rank == sender) {
+      e->region.serialize(send_buf);
+      send_buf.send(recovering, 0, group.set_comm).wait();
+    } else if (!found_here) {
+      recv_buf.recv_unknown(sender, 0, group.set_comm).wait();
+      e->add_and_fit({recv_buf});
+    }
+
+    //Use the same logic as store, but recovering rank is always root and
+    //zeroes out the local data region before participating.
+    int parity_size = e->size() / (group.set_size - 1);
+    int remainder   = e->size() % (group.set_size - 1);
+    if (remainder) remainder++;
+    int m_parity_size = parity_size;
+    if (group.set_rank < remainder) m_parity_size++;
+    e->partner_resize(m_parity_size);
+
+    if (!found_here) {
+      std::memset(e->data(), 0, e->size());
+      std::memset(e->partner_data(), 0, e->partner_size());
+    }
+
+    int offset = 0;
+    for (int i = 0; i < group.set_size; i++) {
+      int len = i < remainder ? parity_size + 1 : parity_size;
+      char* input;
+      if (group.set_rank == i) {
+        input = e->partner_data();
+      } else {
+        if (offset + len > e->size()) offset--;
+        input = e->data() + offset;
+        offset += len;
+      }
+      MPI_Reduce(
+        MPI_IN_PLACE, input, len, MPI_BYTE, MPI_BXOR, recovering, group.set_comm
+      );
+    }
+    assert(offset == e->size());
+
+    e->timestamp = *ts;
+  }
+
+  return FENIX_SUCCESS;
 }
 
 int Member::lrestore(
-   char* target, int max_restore, int timestamp, DataSubset& recovered
-){
-   //Restoring always clears the commit buffer
-   entries.back().reset();
+  char* target, int max_restore, int timestamp, DataSubset& recovered
+) {
+  //Restoring always clears the commit buffer
+  entries.back().reset();
 
-   int end = 0;
-   if(timestamp == FENIX_DATA_SNAPSHOT_LATEST){
-      if(entries[entries.size()-2].timestamp >= 0){
-         end = entries.size()-1;
+  int end = 0;
+  if (timestamp == FENIX_DATA_SNAPSHOT_LATEST) {
+    if (entries[entries.size() - 2].timestamp >= 0) {
+      end = entries.size() - 1;
+    }
+  } else {
+    for (int i = entries.size() - 2; i >= 0; i--) {
+      if (entries[i].timestamp == timestamp) {
+        end = i + 1;
+        break;
       }
-   } else {
-      for(int i = entries.size()-2; i >= 0; i--){
-         if(entries[i].timestamp == timestamp){
-            end = i+1;
-            break;
-         }
-      }
-   }
+    }
+  }
 
-   int begin = end > 0 ? end-1 : end;
-   if(max_restore != 0){
-      for(int i = end-1; i >= 0 && !recovered.includes_all(max_restore-1) ; i--){
-         if(entries[i].timestamp < 0) break;
-         begin = i;
-         recovered += entries[i].region;
-      }
-   } else if(begin < end) {
-      recovered = entries[begin].region;
-   }
+  int begin = end > 0 ? end - 1 : end;
+  if (max_restore != 0) {
+    for (
+      int i = end - 1; i >= 0 && !recovered.includes_all(max_restore - 1); i--
+    ) {
+      if (entries[i].timestamp < 0) break;
+      begin = i;
+      recovered += entries[i].region;
+    }
+  } else if (begin < end) {
+    recovered = entries[begin].region;
+  }
 
-   for(int i = begin; i < end && target != NULL; i++){
-      Entry& e = entries[i];
-      e.region.copy_data(e.elm_size, e.buf, max_restore, target);
-   }
+  for (int i = begin; i < end && target != NULL; i++) {
+    Entry& e = entries[i];
+    e.region.copy_data(e.elm_size, e.buf, max_restore, target);
+  }
 
-   if(end <= 0) return FENIX_ERROR_NODATA_FOUND;
-   if(max_restore != 0 && !recovered.includes_all(max_restore-1))
-      return FENIX_WARNING_PARTIAL_RESTORE;
-   return FENIX_SUCCESS;
+  if (end <= 0) FENIX_THROW(FENIX_ERROR_NODATA_FOUND);
+  if (max_restore != 0 && !recovered.includes_all(max_restore - 1))
+    return FENIX_WARNING_PARTIAL_RESTORE;
+  return FENIX_SUCCESS;
 }
 
 Group::Group(
-   int m_id, MPI_Comm m_comm, int m_timestart, int m_depth,
-   int* policy_vals, int* flag
-) : fenix_group_t(m_id, m_comm, m_timestart, m_depth, FENIX_DATA_POLICY_IMR) {
-   mode = policy_vals ? policy_vals[0] : 1;
-   rank_separation = policy_vals ? policy_vals[1] : __fenix_get_world_size(m_comm)/2;
+  int m_id, MPI_Comm m_comm, int m_timestart, int m_depth, int* policy_vals,
+  int* flag
+)
+  : fenix_group_t(m_id, m_comm, m_timestart, m_depth, FENIX_DATA_POLICY_IMR) {
+  mode = policy_vals ? policy_vals[0] : 1;
+  rank_separation =
+    policy_vals ? policy_vals[1] : __fenix_get_world_size(m_comm) / 2;
 
-   comm = m_comm;
+  comm = m_comm;
 
-   int my_rank, comm_size;
-   MPI_Comm_size(comm, &comm_size);
-   MPI_Comm_rank(comm, &my_rank);
-   current_rank = my_rank;
+  int my_rank, comm_size;
+  MPI_Comm_size(comm, &comm_size);
+  MPI_Comm_rank(comm, &my_rank);
+  current_rank = my_rank;
 
-   std::set<int> partner_set;
-   partner_set.insert(my_rank);
+  std::set<int> partner_set;
+  partner_set.insert(my_rank);
 
-   if(mode == 1){
-      //odd-sized groups take some extra handling.
-      bool isOdd = ((comm_size%2) != 0);
-      
-      int remaining_size = comm_size;
-      if(isOdd) remaining_size -= 3;
-      
-      //We want to form groups of rank_separation*2 to pair within
-      int n_full_groups = remaining_size / (rank_separation*2);
-     
-      //We don't always get what we want though, one group may need to be
-      //smaller.
-      int mini_group_size = 
-         (remaining_size - n_full_groups*rank_separation*2)/2;
-      
-      int start_rank = mini_group_size + (isOdd?1:0);
-      int mid_rank = comm_size/2; //Only used when isOdd
-      
-      int end_mini_group_start = comm_size-mini_group_size-(isOdd?1:0);
-      int start_mini_group_start = (isOdd?1:0);
-      bool in_start_mini = 
-         my_rank >= start_mini_group_start
-            && my_rank < start_mini_group_start+mini_group_size;
-      bool in_end_mini = 
-         my_rank >= end_mini_group_start && my_rank < comm_size-(isOdd?1:0);
+  if (mode == 1) {
+    //odd-sized groups take some extra handling.
+    bool isOdd = ((comm_size % 2) != 0);
 
-      //Allocate the "normal" ranks
-      if(my_rank >= start_rank && my_rank < end_mini_group_start
-            && (!isOdd || my_rank != mid_rank)){
-         //"effective" rank for determining which group I'm in and if I look
-         //forward or backward for a partner.
-         int e_rank = my_rank - start_rank;
-         if(isOdd && my_rank > mid_rank)
-            --e_rank; //We skip the middle rank when isOdd
+    int remaining_size = comm_size;
+    if (isOdd) remaining_size -= 3;
 
-         int my_partner;
-         if(((e_rank/rank_separation)%2) == 0){
-            //Look forward for partner.
-            my_partner = my_rank + rank_separation;
-            if(isOdd && my_rank < mid_rank && my_partner >= mid_rank)
-               ++my_partner;
-         } else {
-            my_partner = my_rank - rank_separation;
-            if(isOdd && my_rank > mid_rank && my_partner <= mid_rank)
-               --my_partner;
-         }
+    //We want to form groups of rank_separation*2 to pair within
+    int n_full_groups = remaining_size / (rank_separation * 2);
 
-         partner_set.insert(my_partner);
-      } else if(in_start_mini) {
-         int e_rank = my_rank - start_mini_group_start;
-         int partner = end_mini_group_start + e_rank;
-         partner_set.insert(partner);
-      } else if(in_end_mini) {
-         int e_rank = my_rank - end_mini_group_start;
-         int partner = start_mini_group_start + e_rank;
-         partner_set.insert(partner);
-      } else { 
-         //Only things left are the three ranks that must be paired to handle
-         //odd-sized comms
-         partner_set.insert({0, mid_rank, comm_size-1});
+    //We don't always get what we want though, one group may need to be
+    //smaller.
+    int mini_group_size =
+      (remaining_size - n_full_groups * rank_separation * 2) / 2;
 
-         //my_rank should be one of the inserted ranks, or something in the
-         //logic here is broken.
-         assert(partner_set.size() == 3 || (comm_size==1 && partner_set.size()==1));
+    int start_rank = mini_group_size + (isOdd ? 1 : 0);
+    int mid_rank   = comm_size / 2; //Only used when isOdd
+
+    int end_mini_group_start   = comm_size - mini_group_size - (isOdd ? 1 : 0);
+    int start_mini_group_start = (isOdd ? 1 : 0);
+    bool in_start_mini         = my_rank >= start_mini_group_start &&
+      my_rank < start_mini_group_start + mini_group_size;
+    bool in_end_mini =
+      my_rank >= end_mini_group_start && my_rank < comm_size - (isOdd ? 1 : 0);
+
+    //Allocate the "normal" ranks
+    if (my_rank >= start_rank && my_rank < end_mini_group_start &&
+        (!isOdd || my_rank != mid_rank)) {
+      //"effective" rank for determining which group I'm in and if I look
+      //forward or backward for a partner.
+      int e_rank = my_rank - start_rank;
+      if (isOdd && my_rank > mid_rank) --e_rank; //Skip middle rank when isOdd
+
+      int my_partner;
+      if (((e_rank / rank_separation) % 2) == 0) {
+        //Look forward for partner.
+        my_partner = my_rank + rank_separation;
+        if (isOdd && my_rank < mid_rank && my_partner >= mid_rank) ++my_partner;
+      } else {
+        my_partner = my_rank - rank_separation;
+        if (isOdd && my_rank > mid_rank && my_partner <= mid_rank) --my_partner;
       }
-   } else if(mode == 5){
-      set_size = policy_vals[2];
 
-      //User is responsible for giving values that "make sense" for set size and rank separation given a comm size.
-      int my_set_pos = (my_rank/rank_separation)%set_size;
-      for(int index = 0; index < set_size; index++){
-        int partner = (comm_size + my_rank - 
-                   rank_separation * (my_set_pos-index)
-                  )%comm_size;
-        partner_set.insert(partner);
-      }
-   }
-   
-   partners = {partner_set.begin(), partner_set.end()};
-   
-   //Make same MPI calls as reinit
-   reinit(flag);
+      partner_set.insert(my_partner);
+    } else if (in_start_mini) {
+      int e_rank  = my_rank - start_mini_group_start;
+      int partner = end_mini_group_start + e_rank;
+      partner_set.insert(partner);
+    } else if (in_end_mini) {
+      int e_rank  = my_rank - end_mini_group_start;
+      int partner = start_mini_group_start + e_rank;
+      partner_set.insert(partner);
+    } else {
+      //Only things left are the three ranks that must be paired to handle
+      //odd-sized comms
+      partner_set.insert({0, mid_rank, comm_size - 1});
+
+      //my_rank should be one of the inserted ranks, or something in the
+      //logic here is broken.
+      fenix_assert(
+        (partner_set.size() == 3 || (comm_size == 1 && partner_set.size() == 1))
+      );
+    }
+  } else if (mode == 5) {
+    set_size = policy_vals[2];
+
+    //User is responsible for giving values that "make sense" for set size and
+    //rank separation given a comm size.
+    int my_set_pos = (my_rank / rank_separation) % set_size;
+    for (int i = 0; i < set_size; i++) {
+      int partner =
+        (comm_size + my_rank - rank_separation * (my_set_pos - i)) % comm_size;
+      partner_set.insert(partner);
+    }
+  }
+
+  partners = {partner_set.begin(), partner_set.end()};
+
+  //Make same MPI calls as reinit
+  reinit(flag);
 }
 
-void Group::build_set_comm(){
-   if(set_comm != MPI_COMM_NULL){
-      MPI_Comm_free(&set_comm);
-      set_comm = MPI_COMM_NULL;
-   }
+void Group::build_set_comm() {
+  if (set_comm != MPI_COMM_NULL) {
+    MPI_Comm_free(&set_comm);
+    set_comm = MPI_COMM_NULL;
+  }
 
-   MPI_Group comm_group, set_group;
-   MPI_Comm_group(comm, &comm_group);
-   MPI_Group_incl(comm_group, partners.size(), partners.data(), &set_group);
-   MPI_Comm_create_group(comm, set_group, 0, &(set_comm));
-   
-   MPI_Group_free(&comm_group);
-   MPI_Group_free(&set_group);
+  MPI_Group comm_group, set_group;
+  MPI_Comm_group(comm, &comm_group);
+  MPI_Group_incl(comm_group, partners.size(), partners.data(), &set_group);
+  MPI_Comm_create_group(comm, set_group, 0, &(set_comm));
 
-   MPI_Comm_size(set_comm, &set_size);
-   MPI_Comm_rank(set_comm, &set_rank);
+  MPI_Group_free(&comm_group);
+  MPI_Group_free(&set_group);
 
-   if(!set_comm_revoke_callback){
-      //TODO: This isn't great, and doesn't work w/ fenix restarts
-      // (ie finalize then init), we need a better way to refer to callbacks
-      // than just push/pop. Maybe a push/pop stack and an add/del map?
-      set_comm_revoke_callback = true;
-      fenix::callback_register([](MPI_Comm, int){
-         auto groups = fenix_rt.data_recovery;
-         if(NULL == groups) return;
-         for(int i = 0; i < groups->count; i++){
-            auto g = groups->group[i];
-            if(g->policy_name != FENIX_DATA_POLICY_IMR) continue;
-            auto imr_g = static_cast<fenix::data::imr::Group*>(g);
+  MPI_Comm_size(set_comm, &set_size);
+  MPI_Comm_rank(set_comm, &set_rank);
 
-            if(imr_g->set_comm == MPI_COMM_NULL) continue;
-            MPIX_Comm_revoke(imr_g->set_comm);
-         }
-      }, PRE_RECOVERY);
-   }
+  if (!set_comm_revoke_callback) {
+    //TODO: This isn't great, and doesn't work w/ fenix restarts
+    // (ie finalize then init), we need a better way to refer to callbacks
+    // than just push/pop. Maybe a push/pop stack and an add/del map?
+    set_comm_revoke_callback = true;
+    fenix::callback_register(
+      [](MPI_Comm, int) {
+        auto groups = fenix_rt.data_recovery;
+        if (NULL == groups) return;
+        for (int i = 0; i < groups->count; i++) {
+          auto g = groups->group[i];
+          if (g->policy_name != FENIX_DATA_POLICY_IMR) continue;
+          auto imr_g = static_cast<fenix::data::imr::Group*>(g);
+
+          if (imr_g->set_comm == MPI_COMM_NULL) continue;
+          MPIX_Comm_revoke(imr_g->set_comm);
+        }
+      },
+      PRE_RECOVERY
+    );
+  }
 }
 
-Member* Group::find_member(int memberid){
-   auto iter = member_data.find(memberid);
-   if(iter != member_data.end()) return iter->second.get();
-   return nullptr;
+Member* Group::find_member(int memberid) {
+  auto iter = member_data.find(memberid);
+  if (iter != member_data.end()) return iter->second.get();
+  return nullptr;
 }
 
-std::string Group::str(){
-   std::stringstream ss;
-   ss << "Group " << groupid << " set ";
-   ss << "[" << partners[0];
-   for(int i=1; i<partners.size(); i++) ss << ", " << partners[i];
-   ss << "]";
+std::string Group::str() {
+  std::stringstream ss;
+  ss << "Group " << groupid << " set ";
+  ss << "[" << partners[0];
+  for (int i = 1; i < partners.size(); i++) ss << ", " << partners[i];
+  ss << "]";
 
-   return ss.str();
+  return ss.str();
 }
 
-int Group::member_create(fenix_member_entry_t* mentry){
-   auto iter = member_data.try_emplace(mentry->memberid, nullptr);
-   if(iter.second){
-      if(mode == 1)
-         iter.first->second = std::make_shared<BuddyMember>(*mentry, *this);
-      else if(mode == 5)
-         iter.first->second = std::make_shared<ParityMember>(*mentry, *this);
-      else assert(false);
+int Group::member_create(fenix_member_entry_t* mentry) {
+  auto iter = member_data.try_emplace(mentry->memberid, nullptr);
+  if (!iter.second) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
 
-      return FENIX_SUCCESS;
-   } else return FENIX_ERROR_MEMBER_EXISTS;
+  auto& m = iter.first->second;
+  if (mode == 1) m = std::make_shared<BuddyMember>(*mentry, *this);
+  else if (mode == 5) m = std::make_shared<ParityMember>(*mentry, *this);
+  else assert(false);
+
+  return FENIX_SUCCESS;
 }
 
-int Group::member_delete(fenix_member_entry_t* mentry){
-   auto iter = member_data.find(mentry->memberid);
+int Group::member_delete(fenix_member_entry_t* mentry) {
+  auto iter = member_data.find(mentry->memberid);
 
-   if(iter == member_data.end()){
-      FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-   }
+  if (iter == member_data.end()) {
+    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  }
 
-   member_data.erase(iter);
-   return FENIX_SUCCESS;
+  member_data.erase(iter);
+  return FENIX_SUCCESS;
 }
 
 void Group::member_stage(int member_id, const DataSubset& subset) {
-   auto iter = member_data.find(member_id);
-   if (iter == member_data.end()) FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-   iter->second->stage(subset);
+  auto iter = member_data.find(member_id);
+  if (iter == member_data.end()) FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  iter->second->stage(subset);
 }
 
-int Group::member_store(int member_id, const DataSubset& subset){
-   auto iter = member_data.find(member_id);
-   if(iter == member_data.end()){
-      debug_print(
-         "ERROR Fenix_Data_member_store: %s unknown member_id %d on rank %d\n",
-         this->str().c_str(), member_id, current_rank
-      );
-      return FENIX_ERROR_INVALID_MEMBERID;
-   }
-   return iter->second->store(subset);
+int Group::member_store(int member_id, const DataSubset& subset) {
+  auto iter = member_data.find(member_id);
+  if (iter == member_data.end()) {
+    debug_print(
+      "ERROR Fenix_Data_member_store: %s unknown member_id %d on rank %d\n",
+      this->str().c_str(), member_id, current_rank
+    );
+    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  }
+  return iter->second->store(subset);
 }
 
-int Group::member_storev(int member_id, const DataSubset& subset){
-   auto iter = member_data.find(member_id);
-   if(iter == member_data.end()){
-      debug_print(
-         "ERROR Fenix_Data_member_storev: %s unknown member_id %d on rank %d\n",
-         this->str().c_str(), member_id, current_rank
-      );
-      return FENIX_ERROR_INVALID_MEMBERID;
-   }
-   return iter->second->storev(subset);
+int Group::member_storev(int member_id, const DataSubset& subset) {
+  auto iter = member_data.find(member_id);
+  if (iter == member_data.end()) {
+    debug_print(
+      "ERROR Fenix_Data_member_storev: %s unknown member_id %d on rank %d\n",
+      this->str().c_str(), member_id, current_rank
+    );
+    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  }
+  return iter->second->storev(subset);
 }
 
 int Group::member_istore(
-   int member_id, const DataSubset& subset, Fenix_Request *request
-) {return 0;}
+  int member_id, const DataSubset& subset, Fenix_Request* request
+) {
+  return 0;
+}
 
 int Group::member_istorev(
-   int member_id, const DataSubset& subset_specifier, Fenix_Request *request
-) {return 0;}
-
-
-int Group::commit(){
-   if(timestamps.size() == depth+1){
-      //Full of timestamps, remove the oldest and proceed as normal.
-      timestamps.pop_front();
-   }
-   timestamps.push_back(timestamp);
-
-   for(auto& iter : member_data){
-      iter.second->commit(timestamp);
-   }
-
-   send_buf.clear();
-   send_buf.shrink_to_fit();
-   recv_buf.clear();
-   recv_buf.shrink_to_fit();
-
-   return FENIX_SUCCESS;
+  int member_id, const DataSubset& subset_specifier, Fenix_Request* request
+) {
+  return 0;
 }
 
+int Group::commit() {
+  if (timestamps.size() == depth + 1) {
+    //Full of timestamps, remove the oldest and proceed as normal.
+    timestamps.pop_front();
+  }
+  timestamps.push_back(timestamp);
 
-int Group::snapshot_delete(int to_delete){
-   int retval = FENIX_SUCCESS;
+  for (auto& iter : member_data) {
+    iter.second->commit(timestamp);
+  }
 
-   bool found = false;
-   for(auto it = timestamps.begin(); it != timestamps.end(); it++){
-      if(*it == to_delete){
-         timestamps.erase(it);
-         found = true;
-         break;
-      }
-   }
-   for(auto& iter : member_data){
-      found |= iter.second->snapshot_delete(to_delete);
-   }
-   return found ? FENIX_SUCCESS : FENIX_ERROR_INVALID_TIMESTAMP;
+  send_buf.clear();
+  send_buf.shrink_to_fit();
+  recv_buf.clear();
+  recv_buf.shrink_to_fit();
+
+  return FENIX_SUCCESS;
 }
 
-int Group::barrier(){return 0;}
+int Group::snapshot_delete(int to_delete) {
+  int retval = FENIX_SUCCESS;
 
-int Group::get_number_of_snapshots(int* num){
-   *num = timestamps.size();
-   return FENIX_SUCCESS;
+  bool found = false;
+  for (auto it = timestamps.begin(); it != timestamps.end(); it++) {
+    if (*it == to_delete) {
+      timestamps.erase(it);
+      found = true;
+      break;
+    }
+  }
+  for (auto& iter : member_data) {
+    found |= iter.second->snapshot_delete(to_delete);
+  }
+  if (!found) FENIX_THROW(FENIX_ERROR_INVALID_TIMESTAMP);
+  return FENIX_SUCCESS;
 }
 
-int Group::get_snapshot_at_position(int idx, int* snapshot){
-   if(idx >= timestamps.size() || idx < 0)
-      return FENIX_ERROR_INVALID_POSITION;
+int Group::barrier() { return 0; }
 
-   *snapshot = timestamps[idx];
-   return FENIX_SUCCESS;
+int Group::get_number_of_snapshots(int* num) {
+  *num = timestamps.size();
+  return FENIX_SUCCESS;
 }
 
-std::vector<int> Group::get_snapshots(){
+int Group::get_snapshot_at_position(int idx, int* snapshot) {
+  if (idx >= timestamps.size() || idx < 0)
+    FENIX_THROW(FENIX_ERROR_INVALID_POSITION);
+
+  *snapshot = timestamps[idx];
+  return FENIX_SUCCESS;
+}
+
+std::vector<int> Group::get_snapshots() {
   return {timestamps.begin(), timestamps.end()};
 }
 
 int Group::member_restore(
-   int member_id, void* target_buffer, int max_count, int ts,
-   DataSubset& data_found
-){
-   //TODO: Is this fix needed anymore?
-   //One-time fix after a reinit.
-   if(timestamp == -1 && !timestamps.empty())
-      timestamp = timestamps.back();
-   
-   Member* member = find_member(member_id);
+  int member_id, void* target_buffer, int max_count, int ts,
+  DataSubset& data_found
+) {
+  //TODO: Is this fix needed anymore?
+  //One-time fix after a reinit.
+  if (timestamp == -1 && !timestamps.empty()) timestamp = timestamps.back();
 
-   std::vector<int> found_members(set_size);
-   found_members[set_rank] = member ? 1 : 0;
+  Member* member = find_member(member_id);
 
-   int allgather_ret = MPI_Allgather(
-     MPI_IN_PLACE, 1, MPI_INT, found_members.data(), 1, MPI_INT, set_comm
-   );
+  std::vector<int> found_members(set_size);
+  found_members[set_rank] = member ? 1 : 0;
 
-   int n_missing = 0;
-   int first_found = -1, missing_rank = -1;
-   for(int i = 0; i < found_members.size(); i++){
-      if(!found_members[i]){
-         n_missing++;
-         missing_rank = i;
-      }
-      if(found_members[i] && first_found == -1)
-         first_found = i;
-   }
+  int allgather_ret = MPI_Allgather(
+    MPI_IN_PLACE, 1, MPI_INT, found_members.data(), 1, MPI_INT, set_comm
+  );
 
-   if(n_missing > 1){
-      if(set_rank != 0) return FENIX_ERROR_INVALID_MEMBERID;
+  int n_missing   = 0;
+  int first_found = -1, missing_rank = -1;
+  for (int i = 0; i < found_members.size(); i++) {
+    if (!found_members[i]) {
+      n_missing++;
+      missing_rank = i;
+    }
+    if (found_members[i] && first_found == -1) first_found = i;
+  }
 
-      if(n_missing == set_size){
-         debug_print(
-            "ERROR Fenix_Data_member_restore: %s member_id %d not found\n",
-            this->str().c_str(), member_id
-         );
-      } else {
-         debug_print(
-            "ERROR Fenix_Data_member_restore: %s member_id %d unrecoverable\n",
-            this->str().c_str(), member_id
-         );
-      }
-      return FENIX_ERROR_INVALID_MEMBERID;
-   } else if(n_missing == 1){
-      fenix_member_entry_packet_t packet;
-      if(set_rank == first_found) packet = member->mentry.to_packet();
+  if (n_missing > 1) {
+    if (set_rank != 0) FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
 
-      MPI_Bcast(
-         &packet, sizeof(packet), MPI_BYTE, first_found, set_comm
+    if (n_missing == set_size) {
+      debug_print(
+        "ERROR Fenix_Data_member_restore: %s member_id %d not found\n",
+        this->str().c_str(), member_id
       );
+    } else {
+      debug_print(
+        "ERROR Fenix_Data_member_restore: %s member_id %d unrecoverable\n",
+        this->str().c_str(), member_id
+      );
+    }
+    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  } else if (n_missing == 1) {
+    fenix_member_entry_packet_t packet;
+    if (set_rank == first_found) packet = member->mentry.to_packet();
 
-      if(!found_members[set_rank]){
-         fenix_group_t::member_create(
-            packet.memberid, target_buffer, packet.current_count,
-            packet.datatype_size
-         );
-         member = find_member(member_id);
-      }
-   }
+    MPI_Bcast(&packet, sizeof(packet), MPI_BYTE, first_found, set_comm);
 
-   member->restore();
+    if (!found_members[set_rank]) {
+      fenix_group_t::member_create(
+        packet.memberid, target_buffer, packet.current_count,
+        packet.datatype_size
+      );
+      member = find_member(member_id);
+    }
+  }
 
-   send_buf.clear();
-   send_buf.shrink_to_fit();
-   recv_buf.clear();
-   recv_buf.shrink_to_fit();
+  member->restore();
 
-   return member->lrestore((char*)target_buffer, max_count, ts, data_found);
+  send_buf.clear();
+  send_buf.shrink_to_fit();
+  recv_buf.clear();
+  recv_buf.shrink_to_fit();
+
+  return member->lrestore((char*)target_buffer, max_count, ts, data_found);
 }
 
 int Group::member_lrestore(
-   int member_id, void* target_buffer, int max_count, int ts,
-   DataSubset& data_found
-){
-   auto iter = member_data.find(member_id);
-   if(iter == member_data.end()) return FENIX_ERROR_INVALID_MEMBERID;
-   return iter->second->lrestore((char*)target_buffer, max_count, ts, data_found);
+  int member_id, void* target_buffer, int max_count, int ts,
+  DataSubset& data_found
+) {
+  auto iter = member_data.find(member_id);
+  if (iter == member_data.end()) FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  return iter->second->lrestore(
+    (char*)target_buffer, max_count, ts, data_found
+  );
 }
 
-
-int Group::member_restore_from_rank(int member_id,
-        void* target_buffer, int max_count, int timestamp, 
-        int source_rank){
-   fenix_assert(false, "restore_from_rank is not supported yet!");
-   return FENIX_ERROR_NOCATEGORY;
+int Group::member_restore_from_rank(
+  int member_id, void* target_buffer, int max_count, int timestamp,
+  int source_rank
+) {
+  fenix_assert(false, "restore_from_rank is not supported yet!");
+  return FENIX_ERROR_NOCATEGORY;
 }
 
+int Group::member_get_attribute(
+  fenix_member_entry_t* member, int attributename, void* attributevalue,
+  int* flag, int sourcerank
+) {
+  return FENIX_SUCCESS;
+}
 
-int Group::member_get_attribute(fenix_member_entry_t* member, 
-        int attributename, void* attributevalue, int* flag, int sourcerank){return 0;}
-
-int Group::member_set_attribute(fenix_member_entry_t* member, 
-           int attributename, void* attributevalue, int* flag){ 
+int Group::member_set_attribute(
+  fenix_member_entry_t* member, int attributename, void* attributevalue,
+  int* flag
+) {
   //No mutable attributes (as of now) require any changes to this policy's info
   return FENIX_SUCCESS;
 }
 
-int Group::reinit(int* flag){
+int Group::reinit(int* flag) {
   build_set_comm();
   sync_timestamps();
 
@@ -946,36 +943,40 @@ int Group::reinit(int* flag){
   return *flag;
 }
 
-void Group::sync_timestamps(){
-   int n_snapshots = timestamps.size();
-   MPI_Allreduce(MPI_IN_PLACE, &n_snapshots, 1, MPI_INT, MPI_MAX, set_comm);
+void Group::sync_timestamps() {
+  int n_snapshots = timestamps.size();
+  MPI_Allreduce(MPI_IN_PLACE, &n_snapshots, 1, MPI_INT, MPI_MAX, set_comm);
 
-   for(int i = timestamps.size(); i < n_snapshots; i++) timestamps.push_front(-1);
+  for (int i = timestamps.size(); i < n_snapshots; i++) {
+    timestamps.push_front(-1);
+  }
 
-   std::vector<int> ts = {timestamps.begin(), timestamps.end()};
-   MPI_Allreduce(
-      MPI_IN_PLACE, ts.data(), n_snapshots, MPI_INT, MPI_MAX, set_comm
-   );
-   timestamps = {ts.begin(), ts.end()};
-   
-   if(!timestamps.empty()) timestamp = timestamps.back();
-   else timestamp = -1;
+  std::vector<int> ts = {timestamps.begin(), timestamps.end()};
+  MPI_Allreduce(
+    MPI_IN_PLACE, ts.data(), n_snapshots, MPI_INT, MPI_MAX, set_comm
+  );
+  timestamps = {ts.begin(), ts.end()};
+
+  if (!timestamps.empty()) timestamp = timestamps.back();
+  else timestamp = -1;
 }
 
-int Group::get_redundant_policy(int* policy_name, void* policy_value, int* flag){
-   *policy_name = FENIX_DATA_POLICY_IN_MEMORY_RAID;
-   
-   int* policy_vals = (int*) policy_value;
-   policy_vals[0] = mode;
-   policy_vals[1] = rank_separation;
-   if(mode == 5) policy_vals[2] = set_size;
+int Group::get_redundant_policy(
+  int* policy_name, void* policy_value, int* flag
+) {
+  *policy_name = FENIX_DATA_POLICY_IN_MEMORY_RAID;
 
-   *flag = FENIX_SUCCESS;
-   return *flag;
+  int* policy_vals = (int*)policy_value;
+  policy_vals[0]   = mode;
+  policy_vals[1]   = rank_separation;
+  if (mode == 5) policy_vals[2] = set_size;
+
+  *flag = FENIX_SUCCESS;
+  return *flag;
 }
 
-int Group::group_delete(){
-   delete this;
-   return FENIX_SUCCESS;
+int Group::group_delete() {
+  delete this;
+  return FENIX_SUCCESS;
 }
 } // namespace fenix::data::imr

--- a/src/fenix_data_recovery.cpp
+++ b/src/fenix_data_recovery.cpp
@@ -228,7 +228,7 @@ int checkpoint(
   FENIX_CPP_API_BEGIN
   util::ScopedActiveMlog scoped_mlog(FENIX_MLOG_NONE);
   bool inline_recovery = scoped_mlog.old_inline_recovery;
-  auto g = find_group(group_id);
+  auto g               = find_group(group_id);
 
   int old_timestamp = g->timestamp;
   while (old_timestamp == g->timestamp) {

--- a/src/fenix_data_subset.cpp
+++ b/src/fenix_data_subset.cpp
@@ -67,766 +67,776 @@ namespace fenix {
 namespace detail {
 
 std::pair<size_t, size_t> DataRegion::range() const {
-   return {start, reps == MAX ? MAX : end+stride*reps};
+  return {start, reps == MAX ? MAX : end + stride * reps};
 }
 
 size_t DataRegion::count() const {
-   if(end == MAX || reps == MAX) return MAX;
-   return (end-start+1)*(reps+1);
+  if (end == MAX || reps == MAX) return MAX;
+  return (end - start + 1) * (reps + 1);
 }
 
 bool DataRegion::operator==(const DataRegion& other) const {
-   return start == other.start && end == other.end && reps == other.reps &&
-      stride == other.stride;
+  return start == other.start && end == other.end && reps == other.reps &&
+    stride == other.stride;
 }
 
 bool DataRegion::operator&&(const DataRegion& b) const {
-   const auto& a = *this;
+  const auto& a = *this;
 
-   auto [astart, aend] = a.range();
-   auto [bstart, bend] = b.range();
-   if(astart > bend || bstart > aend) return false;
-   else if(!a.reps || !b.reps) return true;
+  auto [astart, aend] = a.range();
+  auto [bstart, bend] = b.range();
+  if (astart > bend || bstart > aend) return false;
+  else if (!a.reps || !b.reps) return true;
 
-   //Both are strided. For now, only allow same-stride operations
-   fenix_assert(a.stride == b.stride);
+  //Both are strided. For now, only allow same-stride operations
+  fenix_assert(a.stride == b.stride);
 
-   //Get a big modularly idempotent number to avoid negatives
-   size_t idem = (std::max(aend, bend)/stride + 1)*stride;
+  //Get a big modularly idempotent number to avoid negatives
+  size_t idem = (std::max(aend, bend) / stride + 1) * stride;
 
-   //Start of possible overlap
-   size_t ostart = std::max(astart, bstart);
-   size_t arep = (ostart-astart)/stride;
-   size_t brep = (ostart-bstart)/stride;
-   DataRegion ablock = a.get_rep(arep);
-   DataRegion bblock = b.get_rep(brep);
-   
-   if(ablock && bblock) return true;
-   if(arep < a.reps && (bblock && a.get_rep(arep+1))) return true;
-   if(brep < b.reps && (ablock && b.get_rep(brep+1))) return true;
-   return false;
+  //Start of possible overlap
+  size_t ostart     = std::max(astart, bstart);
+  size_t arep       = (ostart - astart) / stride;
+  size_t brep       = (ostart - bstart) / stride;
+  DataRegion ablock = a.get_rep(arep);
+  DataRegion bblock = b.get_rep(brep);
+
+  if (ablock && bblock) return true;
+  if (arep < a.reps && (bblock && a.get_rep(arep + 1))) return true;
+  if (brep < b.reps && (ablock && b.get_rep(brep + 1))) return true;
+  return false;
 }
 
 bool DataRegion::operator<(const DataRegion& other) const {
-   if(start != other.start) return start < other.start;
-   if(end != other.end) return end < other.end;
-   if(reps != other.reps) return reps < other.reps;
-   return stride < other.stride;
+  if (start != other.start) return start < other.start;
+  if (end != other.end) return end < other.end;
+  if (reps != other.reps) return reps < other.reps;
+  return stride < other.stride;
 }
 
 std::set<DataRegion> DataRegion::operator&(const DataRegion& b) const {
-   fenix_assert(!reps || !b.reps);
-   if(b.reps) return b & *this;
+  fenix_assert(!reps || !b.reps);
+  if (b.reps) return b & *this;
 
-   if(!(*this && b)){
-      return {};
-   } else if(!reps){
-      return {DataRegion({std::max(start, b.start), std::min(end, b.end)})};
-   }
+  if (!(*this && b)) {
+    return {};
+  } else if (!reps) {
+    return {DataRegion({std::max(start, b.start), std::min(end, b.end)})};
+  }
 
-   std::set<DataRegion> ret;
-   
-   size_t start_rep = 0;
-   if(b.start > start){
-      start_rep = (b.start-start)/stride;
-      auto block = get_rep(start_rep);
-      auto valid = block & b;
-      if(!valid.count(block)){
-         ret.merge(valid);
-         if(start_rep == reps) return ret;
-         else start_rep++;
-      }
-   }
+  std::set<DataRegion> ret;
 
-   size_t end_rep = reps;
-   if(b.end < range().second){
-      end_rep = (b.end-start)/stride;
-      if(end_rep < start_rep) return ret;
+  size_t start_rep = 0;
+  if (b.start > start) {
+    start_rep  = (b.start - start) / stride;
+    auto block = get_rep(start_rep);
+    auto valid = block & b;
+    if (!valid.count(block)) {
+      ret.merge(valid);
+      if (start_rep == reps) return ret;
+      else start_rep++;
+    }
+  }
 
-      auto block = get_rep(end_rep);
-      auto valid = block & b;
-      if(!valid.count(block)){
-         ret.merge(valid);
-         if(end_rep == start_rep) return ret;
-         else end_rep--;
-      }
-   }
+  size_t end_rep = reps;
+  if (b.end < range().second) {
+    end_rep = (b.end - start) / stride;
+    if (end_rep < start_rep) return ret;
 
-   ret.insert(get_reps(start_rep, end_rep));
-   return ret;
+    auto block = get_rep(end_rep);
+    auto valid = block & b;
+    if (!valid.count(block)) {
+      ret.merge(valid);
+      if (end_rep == start_rep) return ret;
+      else end_rep--;
+    }
+  }
+
+  ret.insert(get_reps(start_rep, end_rep));
+  return ret;
 }
 
 DataRegion DataRegion::get_rep(size_t n) const {
-   fenix_assert(n <= reps);
-   return DataRegion({start+n*stride, end+n*stride});
+  fenix_assert(n <= reps);
+  return DataRegion({start + n * stride, end + n * stride});
 }
 
 DataRegion DataRegion::get_reps(size_t first, size_t last) const {
-   fenix_assert(first <= last);
-   fenix_assert(last <= reps);
-   return DataRegion(
-      {start+first*stride, end+first*stride}, last-first, stride
-   );
+  fenix_assert(first <= last);
+  fenix_assert(last <= reps);
+  return DataRegion(
+    {start + first * stride, end + first * stride}, last - first, stride
+  );
 }
 
 DataRegion DataRegion::inverted() const {
-   fenix_assert(reps);
-   return DataRegion({end+1, start+stride-1}, reps == MAX ? MAX : reps-1, stride);
+  fenix_assert(reps);
+  return DataRegion(
+    {end + 1, start + stride - 1}, reps == MAX ? MAX : reps - 1, stride
+  );
 }
 
 std::optional<DataRegion> DataRegion::try_merge(const DataRegion& b) const {
-   if(b < *this){
-      return b.try_merge(*this);
-   } else if(range().second == MAX){
-      return {};
-   } else if(!reps && !b.reps){
-      if(end+1 == b.start) return DataRegion({start, b.end});
-      else return {};
-   } else {
-      size_t s = reps ? stride : b.stride;
-      if(start+s*(reps+1) == b.start && end+s*(reps+1) == b.end)
-         return DataRegion({start, end}, reps+b.reps+1, s);
-      else return {};
-   }
+  if (b < *this) {
+    return b.try_merge(*this);
+  } else if (range().second == MAX) {
+    return {};
+  } else if (!reps && !b.reps) {
+    if (end + 1 == b.start) return DataRegion({start, b.end});
+    else return {};
+  } else {
+    size_t s = reps ? stride : b.stride;
+    if (start + s * (reps + 1) == b.start && end + s * (reps + 1) == b.end)
+      return DataRegion({start, end}, reps + b.reps + 1, s);
+    else return {};
+  }
 }
 
-void merge_adjacent_sets(std::set<DataRegion>& a, std::set<DataRegion>& b){
-   if(a.empty()){
-      a = std::move(b);
-      b = {};
-   }
-   while(!b.empty()){
-      auto merged = (--a.end())->try_merge(*b.begin());
-      if(!merged){
-         a.merge(b);
-         b.clear();
-      } else {
-         a.erase(--a.end());
-         b.erase(b.begin());
-         a.insert(merged.value());
-      }
-   }
-   while(a.size() > 1){
-      auto merged = (----a.end())->try_merge(*(--a.end()));
-      if(!merged) break;
+void merge_adjacent_sets(std::set<DataRegion>& a, std::set<DataRegion>& b) {
+  if (a.empty()) {
+    a = std::move(b);
+    b = {};
+  }
+  while (!b.empty()) {
+    auto merged = (--a.end())->try_merge(*b.begin());
+    if (!merged) {
+      a.merge(b);
+      b.clear();
+    } else {
       a.erase(--a.end());
-      a.erase(--a.end());
+      b.erase(b.begin());
       a.insert(merged.value());
-   }
+    }
+  }
+  while (a.size() > 1) {
+    auto merged = (-- --a.end())->try_merge(*(--a.end()));
+    if (!merged) break;
+    a.erase(--a.end());
+    a.erase(--a.end());
+    a.insert(merged.value());
+  }
 }
 
 std::set<DataRegion> DataRegion::operator-(const DataRegion& b) const {
-   if(!(*this && b)) return {*this};
-   fenix_assert(!reps || !b.reps || stride == b.stride);
+  if (!(*this && b)) return {*this};
+  fenix_assert(!reps || !b.reps || stride == b.stride);
 
-   const auto [bstart, bend] = b.range();
+  const auto [bstart, bend] = b.range();
 
-   std::set<DataRegion> ret;
-   if(bstart > 0) ret.merge(*this & DataRegion({0, bstart-1}));
-   if(b.reps){
-      std::set<DataRegion> mid;
-      auto inv = b.inverted();
-      
-      //Get just the portions of myself that could be overlapping
-      auto parts = *this & DataRegion({bstart, bend});
+  std::set<DataRegion> ret;
+  if (bstart > 0) ret.merge(*this & DataRegion({0, bstart - 1}));
+  if (b.reps) {
+    std::set<DataRegion> mid;
+    auto inv = b.inverted();
 
-      //Handle any non-strided portions individually
-      for(auto it = parts.begin(); it != parts.end();){
-         if(it->reps){
-            it++;
-            continue;
-         } else {
-            mid.merge(*it & inv);
-            it = parts.erase(it);
-         }
+    //Get just the portions of myself that could be overlapping
+    auto parts = *this & DataRegion({bstart, bend});
+
+    //Handle any non-strided portions individually
+    for (auto it = parts.begin(); it != parts.end();) {
+      if (it->reps) {
+        it++;
+        continue;
+      } else {
+        mid.merge(*it & inv);
+        it = parts.erase(it);
       }
+    }
 
-      //Should have taken care of everything, or left only 1 strided region
-      if(!parts.empty()){
-         fenix_assert(parts.size() == 1);
-         auto a = *parts.begin();
-         //First, middle, and last repetitions may be effected differently
-         mid.merge(a.get_rep(0) & inv);
-         if(a.reps > 1){
-            size_t middle_reps = a.reps-2;
-            auto middle_valid = a.get_rep(1) & inv;
-            for(auto block : middle_valid){
-               fenix_assert(!block.reps);
-               mid.insert(DataRegion(
-                  {block.start, block.end}, a.reps-2, b.stride
-               ));
-            }
-         }
-         mid.merge(a.get_rep(a.reps) & inv);
+    //Should have taken care of everything, or left only 1 strided region
+    if (!parts.empty()) {
+      fenix_assert(parts.size() == 1);
+      auto a = *parts.begin();
+      //First, middle, and last repetitions may be effected differently
+      mid.merge(a.get_rep(0) & inv);
+      if (a.reps > 1) {
+        size_t middle_reps = a.reps - 2;
+        auto middle_valid  = a.get_rep(1) & inv;
+        for (auto block : middle_valid) {
+          fenix_assert(!block.reps);
+          mid.insert(
+            DataRegion({block.start, block.end}, a.reps - 2, b.stride)
+          );
+        }
       }
-      merge_adjacent_sets(ret, mid);
-   }
-   if(bend != MAX){
-      auto post = *this & DataRegion({bend+1, MAX});
-      merge_adjacent_sets(ret, post);
-   }
-   return ret;
+      mid.merge(a.get_rep(a.reps) & inv);
+    }
+    merge_adjacent_sets(ret, mid);
+  }
+  if (bend != MAX) {
+    auto post = *this & DataRegion({bend + 1, MAX});
+    merge_adjacent_sets(ret, post);
+  }
+  return ret;
 }
 
 std::string DataRegion::str() const {
-   std::string ret = "[";
+  std::string ret = "[";
 
-   if(start == MAX) ret += "MAX";
-   else ret += std::to_string(start);
+  if (start == MAX) ret += "MAX";
+  else ret += std::to_string(start);
 
-   ret += ",";
+  ret += ",";
 
-   if(end == MAX) ret += "MAX";
-   else ret += std::to_string(end);
+  if (end == MAX) ret += "MAX";
+  else ret += std::to_string(end);
 
-   ret += "]";
+  ret += "]";
 
-   if(reps){
-      ret += "x" + std::to_string(reps+1) + "s" + std::to_string(stride);
-   }
-   return ret;
+  if (reps) {
+    ret += "x" + std::to_string(reps + 1) + "s" + std::to_string(stride);
+  }
+  return ret;
 }
 
 DataRegion full_region({0, DataRegion::MAX});
 
 struct BlockIter {
-   using set_t = std::set<DataRegion>;
-   using iter_t = typename set_t::iterator;
+  using set_t  = std::set<DataRegion>;
+  using iter_t = typename set_t::iterator;
 
-   BlockIter(set_t&& m_regions) 
-      : region_holder(std::make_shared<set_t>(std::move(m_regions))),
-        regions(*region_holder), it(regions.begin()), rep(0) { }
-   BlockIter(std::shared_ptr<set_t> m_regions) 
-      : region_holder(m_regions),
-        regions(*region_holder), it(regions.begin()), rep(0) { }
-   BlockIter(const BlockIter& other)
-      : region_holder(other.region_holder), regions(other.regions), it(other.it), rep(other.rep) {
-      fenix_assert(rep <= it->reps);
-      ++*this;
-   }
+  BlockIter(set_t&& m_regions)
+    : region_holder(std::make_shared<set_t>(std::move(m_regions))),
+      regions(*region_holder), it(regions.begin()), rep(0) {}
+  BlockIter(std::shared_ptr<set_t> m_regions)
+    : region_holder(m_regions), regions(*region_holder), it(regions.begin()),
+      rep(0) {}
+  BlockIter(const BlockIter& other)
+    : region_holder(other.region_holder), regions(other.regions), it(other.it),
+      rep(other.rep) {
+    fenix_assert(rep <= it->reps);
+    ++*this;
+  }
 
-   DataRegion operator*(){
-      return it->get_rep(rep);
-   }
+  DataRegion operator*() { return it->get_rep(rep); }
 
-   bool operator==(const BlockIter& other) const {
-      return it == other.it && rep == other.rep;
-   }
-   bool operator!=(const BlockIter& other) const {
-      return !(*this == other);
-   }
+  bool operator==(const BlockIter& other) const {
+    return it == other.it && rep == other.rep;
+  }
+  bool operator!=(const BlockIter& other) const { return !(*this == other); }
 
-   BlockIter begin(){
-      return BlockIter(region_holder);
-   }
+  BlockIter begin() { return BlockIter(region_holder); }
 
-   BlockIter end(){
-      auto ret = begin();
-      ret.it = regions.end();
-      return ret;
-   }
+  BlockIter end() {
+    auto ret = begin();
+    ret.it   = regions.end();
+    return ret;
+  }
 
-   BlockIter& operator++(){
-      if(rep == it->reps){
-         ++it;
-         rep = 0;
-      } else {
-         ++rep;
-      }
-      return *this;
-   }
-   
-   std::shared_ptr<set_t> region_holder;
+  BlockIter& operator++() {
+    if (rep == it->reps) {
+      ++it;
+      rep = 0;
+    } else {
+      ++rep;
+    }
+    return *this;
+  }
 
-   const set_t& regions;
-   iter_t it;
-   size_t rep;
+  std::shared_ptr<set_t> region_holder;
 
+  const set_t& regions;
+  iter_t it;
+  size_t rep;
 };
 
 } // namespace detail
 
 using namespace detail;
 
-DataSubset::DataSubset(size_t end) : DataSubset({0, end}) { }
+DataSubset::DataSubset(size_t end) : DataSubset({0, end}) {}
 
 DataSubset::DataSubset(std::pair<size_t, size_t> bounds)
-   : DataSubset(bounds, 1, DataRegion::MAX) { };
+  : DataSubset(bounds, 1, DataRegion::MAX) {};
 
 DataSubset::DataSubset(
-   std::pair<size_t, size_t> bounds, size_t n, size_t stride
+  std::pair<size_t, size_t> bounds, size_t n, size_t stride
 ) {
-   fenix_assert(bounds.first <= bounds.second,
-      "subset start (%lu) cannot be after end (%lu)",
-      bounds.first, bounds.second
-   );
-   fenix_assert(n > 0, "num_blocks (%lu) must be positive", n);
-   fenix_assert(n == 1 || bounds.first+stride > bounds.second,
-      "stride %lu too low for region [%lu, %lu]",
-      stride, bounds.first, bounds.second
-   );
-   
-   regions.emplace(bounds, n-1, stride);
+  fenix_assert(
+    bounds.first <= bounds.second,
+    "subset start (%lu) cannot be after end (%lu)", bounds.first, bounds.second
+  );
+  fenix_assert(n > 0, "num_blocks (%lu) must be positive", n);
+  fenix_assert(
+    n == 1 || bounds.first + stride > bounds.second,
+    "stride %lu too low for region [%lu, %lu]", stride, bounds.first,
+    bounds.second
+  );
+
+  regions.emplace(bounds, n - 1, stride);
 }
 
-DataSubset::DataSubset(std::vector<std::pair<size_t, size_t>> bounds){
-   for(const auto& b : bounds){
-      fenix_assert(b.first <= b.second,
-         "subset start (%lu) cannot be after end (%lu)", b.first, b.second
-      );
-      regions.emplace(b);
-   }
+DataSubset::DataSubset(std::vector<std::pair<size_t, size_t>> bounds) {
+  for (const auto& b : bounds) {
+    fenix_assert(
+      b.first <= b.second, "subset start (%lu) cannot be after end (%lu)",
+      b.first, b.second
+    );
+    regions.emplace(b);
+  }
 
-   //Simplify regions
-   merge_regions();
+  //Simplify regions
+  merge_regions();
 }
 
-DataSubset::DataSubset(int num_blocks, int* firsts, int* seconds){
-   fenix_assert(num_blocks > 0, "num_blocks (%d) must be positive", num_blocks);
+DataSubset::DataSubset(int num_blocks, int* firsts, int* seconds) {
+  fenix_assert(num_blocks > 0, "num_blocks (%d) must be positive", num_blocks);
 
-   std::vector<std::pair<size_t, size_t>> bounds;
-   bounds.reserve(num_blocks);
-   for(int i = 0; i < num_blocks; i++) bounds.push_back({firsts[i], seconds[i]});
+  std::vector<std::pair<size_t, size_t>> bounds;
+  bounds.reserve(num_blocks);
+  for (int i = 0; i < num_blocks; i++)
+    bounds.push_back({firsts[i], seconds[i]});
 
-   *this = DataSubset(bounds);
+  *this = DataSubset(bounds);
 }
 
-DataSubset::DataSubset(const DataSubset& a, const DataSubset& b){
-   fenix_assert(a.type == BasicSubset && b.type == BasicSubset);
+DataSubset::DataSubset(const DataSubset& a, const DataSubset& b) {
+  fenix_assert(a.type == BasicSubset && b.type == BasicSubset);
 
-   if(a.empty() || b.empty()){
-      *this = a.empty() ? b : a;
-      return;
-   }
-   if(a.regions.count(full_region) || b.regions.count(full_region)){
-      regions.insert(full_region);
-      return;
-   }
+  if (a.empty() || b.empty()) {
+    *this = a.empty() ? b : a;
+    return;
+  }
+  if (a.regions.count(full_region) || b.regions.count(full_region)) {
+    regions.insert(full_region);
+    return;
+  }
 
-   size_t a_stride = 0, b_stride = 0;
-   for(const auto& r : a.regions) if(r.reps) a_stride = r.stride;
-   for(const auto& r : b.regions) if(r.reps) b_stride = r.stride;
+  size_t a_stride = 0, b_stride = 0;
+  for (const auto& r : a.regions)
+    if (r.reps) a_stride = r.stride;
+  for (const auto& r : b.regions)
+    if (r.reps) b_stride = r.stride;
 
-   if(a_stride && b_stride && a_stride != b_stride){
-      //De-stride A's regions
-      for(const auto& r : a.regions){
-         fenix_assert(r.reps != MAX);
-         for(int i = 0; i <= r.reps; i++)
-            regions.insert(r.get_rep(i));
+  if (a_stride && b_stride && a_stride != b_stride) {
+    //De-stride A's regions
+    for (const auto& r : a.regions) {
+      fenix_assert(r.reps != MAX);
+      for (int i = 0; i <= r.reps; i++) regions.insert(r.get_rep(i));
+    }
+  } else {
+    regions = a.regions;
+  }
+
+  for (const auto& br : b.regions) {
+    const auto [bstart, bend]   = br.range();
+    std::set<DataRegion> adding = {br};
+    for (const auto& r : regions) {
+      const auto [rstart, rend] = r.range();
+      if (rstart > bend) break;
+      if (rend < bstart) continue;
+      for (auto it = adding.begin(); it != adding.end();) {
+        auto valid = *it - r;
+        if (valid.size() == 1 && valid.count(*it)) {
+          it++;
+        } else {
+          it = adding.erase(it);
+          adding.merge(valid);
+        }
       }
-   } else {
-      regions = a.regions;
-   }
-   
-   for(const auto& br : b.regions){
-      const auto [bstart, bend] = br.range();
-      std::set<DataRegion> adding = {br};
-      for(const auto& r : regions){
-         const auto [rstart, rend] = r.range();
-         if(rstart > bend) break;
-         if(rend < bstart) continue;
-         for(auto it = adding.begin(); it != adding.end();){
-            auto valid = *it - r;
-            if(valid.size() == 1 && valid.count(*it)){
-               it++;
-            } else {
-               it = adding.erase(it);
-               adding.merge(valid);
-            }
-         }
-      }
-      regions.merge(adding);
-   }
-   
-   //Final attempt to simplify all regions
-   merge_regions();
+    }
+    regions.merge(adding);
+  }
+
+  //Final attempt to simplify all regions
+  merge_regions();
 }
 
 void DataSubset::merge_regions() {
-   auto check = regions.begin();
-   while(check != regions.end()){
-      auto crange = check->range();
-     
-      bool erase = false;
-      for(auto i = std::next(check); i != regions.end(); i++){
-         if(crange.second < i->start-1) break;
+  auto check = regions.begin();
+  while (check != regions.end()) {
+    auto crange = check->range();
 
-         size_t merge_idx = -1;
-         size_t merge_reps = -1;
+    bool erase = false;
+    for (auto i = std::next(check); i != regions.end(); i++) {
+      if (crange.second < i->start - 1) break;
 
-         size_t matching_end = i->start-1;
-         size_t matching_start = i->end+1;
-         if((matching_end - check->end)%check->stride == 0){
-            merge_idx = (matching_end-check->end)/check->stride;
-            merge_reps = std::min(check->reps-merge_idx, i->reps);
+      size_t merge_idx  = -1;
+      size_t merge_reps = -1;
 
-            //Add the merged region
-            regions.insert(DataRegion(
-               {check->start+merge_idx*check->stride, i->end},
-               merge_reps, check->stride
-            ));
-         } else if((matching_start - check->start)%check->stride == 0){
-            merge_idx = (matching_start-check->start)/check->stride;
-            merge_reps = std::min(check->reps-merge_idx, i->reps);
+      size_t matching_end   = i->start - 1;
+      size_t matching_start = i->end + 1;
+      if ((matching_end - check->end) % check->stride == 0) {
+        merge_idx  = (matching_end - check->end) / check->stride;
+        merge_reps = std::min(check->reps - merge_idx, i->reps);
 
-            //Add the merged region
-            regions.insert(DataRegion(
-               {i->start, check->end+merge_idx*check->stride},
-               merge_reps, check->stride
-            ));
-         }
+        //Add the merged region
+        regions.insert(DataRegion(
+          {check->start + merge_idx * check->stride, i->end}, merge_reps,
+          check->stride
+        ));
+      } else if ((matching_start - check->start) % check->stride == 0) {
+        merge_idx  = (matching_start - check->start) / check->stride;
+        merge_reps = std::min(check->reps - merge_idx, i->reps);
 
-         if(merge_idx != -1){
-            erase = true;
-
-            //Add any blocks before the merge
-            if(merge_idx > 0){
-               regions.insert(DataRegion(
-                  {check->start, check->end}, merge_idx-1, check->stride
-               ));
-            }
-            //Add any blocks after the merge
-            if(merge_idx+merge_reps < check->reps){
-               size_t n_pre = merge_idx+merge_reps+1;
-               size_t offset = n_pre*check->stride;
-               regions.insert(DataRegion(
-                  {check->start+offset, check->end+offset},
-                  check->reps-n_pre, check->stride
-               ));
-            } else if(merge_reps < i->reps){
-               size_t n_pre = merge_reps+1;
-               size_t offset = n_pre*i->stride;
-               regions.insert(DataRegion(
-                  {i->start+offset, i->end+offset},
-                  i->reps-n_pre, i->stride
-               ));
-            }
-            
-            regions.erase(i);
-            break;
-         }
+        //Add the merged region
+        regions.insert(DataRegion(
+          {i->start, check->end + merge_idx * check->stride}, merge_reps,
+          check->stride
+        ));
       }
 
-      auto it = check++;
-      if(erase){
-         regions.erase(it);
+      if (merge_idx != -1) {
+        erase = true;
+
+        //Add any blocks before the merge
+        if (merge_idx > 0) {
+          regions.insert(
+            DataRegion({check->start, check->end}, merge_idx - 1, check->stride)
+          );
+        }
+        //Add any blocks after the merge
+        if (merge_idx + merge_reps < check->reps) {
+          size_t n_pre  = merge_idx + merge_reps + 1;
+          size_t offset = n_pre * check->stride;
+          regions.insert(DataRegion(
+            {check->start + offset, check->end + offset}, check->reps - n_pre,
+            check->stride
+          ));
+        } else if (merge_reps < i->reps) {
+          size_t n_pre  = merge_reps + 1;
+          size_t offset = n_pre * i->stride;
+          regions.insert(DataRegion(
+            {i->start + offset, i->end + offset}, i->reps - n_pre, i->stride
+          ));
+        }
+
+        regions.erase(i);
+        break;
       }
-   }
+    }
+
+    auto it = check++;
+    if (erase) {
+      regions.erase(it);
+    }
+  }
 }
 
-DataSubset::DataSubset(const DataBuffer& buf){
-   fenix_assert(buf.size()%sizeof(DataRegion) == 0);
-   
-   size_t n_regions = buf.size()/sizeof(DataRegion);
-   if(n_regions == 0) return;
+DataSubset::DataSubset(const DataBuffer& buf) {
+  fenix_assert(buf.size() % sizeof(DataRegion) == 0);
 
-   DataRegion* r = (DataRegion*) buf.data();
-   for(int i = 0; i < n_regions; i++){
-      regions.insert(*(r++));
-   }
+  size_t n_regions = buf.size() / sizeof(DataRegion);
+  if (n_regions == 0) return;
+
+  DataRegion* r = (DataRegion*)buf.data();
+  for (int i = 0; i < n_regions; i++) {
+    regions.insert(*(r++));
+  }
 }
 
 void DataSubset::serialize(DataBuffer& buf) const {
-   buf.reset(regions.size()*sizeof(DataRegion));
-   DataRegion* r = (DataRegion*) buf.data();
-   for(const auto& region : regions){
-      *(r++) = region;
-   }
+  buf.reset(regions.size() * sizeof(DataRegion));
+  DataRegion* r = (DataRegion*)buf.data();
+  for (const auto& region : regions) {
+    *(r++) = region;
+  }
 }
 
 DataSubset DataSubset::operator+(const DataSubset& other) const {
-   fenix_assert(type == BasicSubset && other.type == BasicSubset);
-   return DataSubset(*this, other);
+  fenix_assert(type == BasicSubset && other.type == BasicSubset);
+  return DataSubset(*this, other);
 }
 
 DataSubset DataSubset::operator+(const Fenix_Data_subset& other) const {
-   return *this + *(DataSubset*)other.impl;
+  return *this + *(DataSubset*)other.impl;
 }
 
 DataSubset& DataSubset::operator+=(const DataSubset& other) {
-   fenix_assert(type == BasicSubset && other.type == BasicSubset);
-   *this = *this + other;
-   return *this;
+  fenix_assert(type == BasicSubset && other.type == BasicSubset);
+  *this = *this + other;
+  return *this;
 }
 
 DataSubset& DataSubset::operator+=(const Fenix_Data_subset& other) {
-   return *this += *(DataSubset*)other.impl;
+  return *this += *(DataSubset*)other.impl;
 }
 
 DataSubset DataSubset::operator-(const DataSubset& other) const {
-   fenix_assert(type == BasicSubset && other.type == BasicSubset);
-   if(empty() || other.empty()) return *this;
+  fenix_assert(type == BasicSubset && other.type == BasicSubset);
+  if (empty() || other.empty()) return *this;
 
-   size_t a_stride = 0, b_stride = 0;
-   for(const auto& r :       regions) if(r.reps) a_stride = r.stride;
-   for(const auto& r : other.regions) if(r.reps) b_stride = r.stride;
+  size_t a_stride = 0, b_stride = 0;
+  for (const auto& r : regions)
+    if (r.reps) a_stride = r.stride;
+  for (const auto& r : other.regions)
+    if (r.reps) b_stride = r.stride;
 
-   fenix_assert(!(
-      a_stride && b_stride && a_stride != b_stride &&
-      end() == MAX && other.end() == MAX
-   ));
+  fenix_assert(
+    !(a_stride && b_stride && a_stride != b_stride && end() == MAX &&
+      other.end() == MAX)
+  );
 
-   std::set<DataRegion> remaining;
-   if(a_stride && b_stride && a_stride != b_stride){
-      size_t b_end = other.end();
+  std::set<DataRegion> remaining;
+  if (a_stride && b_stride && a_stride != b_stride) {
+    size_t b_end = other.end();
 
-      //Insert individual repetitions possibly overlapping regions
-      for(const auto& b : BlockIter(bounded_regions(0, b_end))){
-         remaining.insert(b);
+    //Insert individual repetitions possibly overlapping regions
+    for (const auto& b : BlockIter(bounded_regions(0, b_end))) {
+      remaining.insert(b);
+    }
+    if (b_end != MAX) {
+      //Leave non-overlapping regions strided
+      auto br = bounded_regions(b_end + 1, MAX);
+      for (const auto& b : br) {
+        remaining.insert(b);
       }
-      if(b_end != MAX){
-         //Leave non-overlapping regions strided
-         auto br = bounded_regions(b_end+1, MAX);
-         for(const auto& b : br){
-            remaining.insert(b);
-         }
-      }
-   } else {
-      remaining = regions;
-   }
+    }
+  } else {
+    remaining = regions;
+  }
 
-   for(const auto& b_r : other.regions){
-      auto next = remaining.begin();
-      while(next != remaining.end()){
-         auto it = next++;
+  for (const auto& b_r : other.regions) {
+    auto next = remaining.begin();
+    while (next != remaining.end()) {
+      auto it = next++;
 
-         if(b_r.start > it->range().second) continue;
-         if(it->start > b_r.range().second) break;
+      if (b_r.start > it->range().second) continue;
+      if (it->start > b_r.range().second) break;
 
-         auto r = *it;
-         remaining.erase(it);
-         remaining.merge(r - b_r);
-      }
-   }
+      auto r = *it;
+      remaining.erase(it);
+      remaining.merge(r - b_r);
+    }
+  }
 
-   DataSubset c;
-   c.regions = std::move(remaining);
-   c.merge_regions();
-   return c; 
+  DataSubset c;
+  c.regions = std::move(remaining);
+  c.merge_regions();
+  return c;
 }
 
 bool DataSubset::operator==(const DataSubset& other) const {
-   if(type != BasicSubset || other.type != BasicSubset)
-      return type == other.type;
-   //Making checks in approximate order of cost
-   if(start() != other.start()) return false;
-   if(regions.empty() != other.regions.empty()) return false;
-   if(regions == other.regions) return true;
-   if(end() != other.end()) return false;
+  if (type != BasicSubset || other.type != BasicSubset)
+    return type == other.type;
+  //Making checks in approximate order of cost
+  if (start() != other.start()) return false;
+  if (regions.empty() != other.regions.empty()) return false;
+  if (regions == other.regions) return true;
+  if (end() != other.end()) return false;
 
-   size_t a_stride = 0, b_stride = 0;
-   for(const auto& r :       regions) if(r.reps) a_stride = r.stride;
-   for(const auto& r : other.regions) if(r.reps) b_stride = r.stride;
+  size_t a_stride = 0, b_stride = 0;
+  for (const auto& r : regions)
+    if (r.reps) a_stride = r.stride;
+  for (const auto& r : other.regions)
+    if (r.reps) b_stride = r.stride;
 
-   //We won't try comparing infinite regions of different strides.
-   if(a_stride && b_stride && a_stride != b_stride && end() == MAX)
-      return false;
+  //We won't try comparing infinite regions of different strides.
+  if (a_stride && b_stride && a_stride != b_stride && end() == MAX)
+    return false;
 
-   return (*this - other).empty() && (other - *this).empty();
+  return (*this - other).empty() && (other - *this).empty();
 }
 
 bool DataSubset::operator!=(const DataSubset& other) const {
-   return !(*this == other);
+  return !(*this == other);
 }
 
 bool DataSubset::empty() const {
-   fenix_assert(type == BasicSubset);
-   return regions.empty();
+  fenix_assert(type == BasicSubset);
+  return regions.empty();
 }
 
 std::pair<size_t, size_t> DataSubset::range() const {
-   fenix_assert(type == BasicSubset);
-   return {start(), end()};
+  fenix_assert(type == BasicSubset);
+  return {start(), end()};
 }
 
 size_t DataSubset::start() const {
-   fenix_assert(type == BasicSubset);
-   if(regions.empty()) return -1;
-   return regions.begin()->start;
+  fenix_assert(type == BasicSubset);
+  if (regions.empty()) return -1;
+  return regions.begin()->start;
 }
 
 size_t DataSubset::end() const {
-   fenix_assert(type == BasicSubset);
-   if(empty()) return -1;
+  fenix_assert(type == BasicSubset);
+  if (empty()) return -1;
 
-   size_t ret = 0;
-   for(const auto& r : regions){
-      ret = std::max(ret, r.range().second);
-   }
-   return ret;
+  size_t ret = 0;
+  for (const auto& r : regions) {
+    ret = std::max(ret, r.range().second);
+  }
+  return ret;
 }
 
 std::set<DataRegion> DataSubset::bounded_regions(size_t max_idx) const {
-   return bounded_regions(0, max_idx);
+  return bounded_regions(0, max_idx);
 }
 
 std::set<DataRegion> DataSubset::bounded_regions(
-   size_t start, size_t end
+  size_t start, size_t end
 ) const {
-   fenix_assert(type == BasicSubset);
-   std::set<DataRegion> ret;
-   DataRegion bounds({start, end});
-   for(const auto& r : regions){
-      if(r.start > end) break;
-      if(r.range().second < start) continue;
-      ret.merge(r & bounds);
-   }
-   return ret;
+  fenix_assert(type == BasicSubset);
+  std::set<DataRegion> ret;
+  DataRegion bounds({start, end});
+  for (const auto& r : regions) {
+    if (r.start > end) break;
+    if (r.range().second < start) continue;
+    ret.merge(r & bounds);
+  }
+  return ret;
 }
 
 size_t DataSubset::count(size_t max_index) const {
-   fenix_assert(type == BasicSubset);
-   size_t ret = 0;
-   for(const auto& r : bounded_regions(max_index)){
-      size_t c = r.count();
-      if(c == MAX) return 0;
-      ret+= c;
-   }
-   return ret;
+  fenix_assert(type == BasicSubset);
+  size_t ret = 0;
+  for (const auto& r : bounded_regions(max_index)) {
+    size_t c = r.count();
+    if (c == MAX) return 0;
+    ret += c;
+  }
+  return ret;
 }
 
 size_t DataSubset::max_count() const {
-   fenix_assert(type == BasicSubset);
-   return end()+1;
+  fenix_assert(type == BasicSubset);
+  return end() + 1;
 }
 
 void DataSubset::serialize_data(
-   size_t elm_size, const DataBuffer& src, DataBuffer& dst
+  size_t elm_size, const DataBuffer& src, DataBuffer& dst
 ) const {
-   fenix_assert(type == BasicSubset);
-   if(regions.empty()){
-      dst.resize(0);
-      return;
-   }
-   fenix_assert(src.size()%elm_size == 0);
-   const size_t max_elm = src.size()/elm_size-1;
+  fenix_assert(type == BasicSubset);
+  if (regions.empty()) {
+    dst.resize(0);
+    return;
+  }
+  fenix_assert(src.size() % elm_size == 0);
+  const size_t max_elm = src.size() / elm_size - 1;
 
-   dst.reset(count(max_elm) * elm_size);
-   char* ptr = dst.data();
-   
-   for(const auto b : BlockIter(bounded_regions(max_elm))){
-      size_t start = b.start*elm_size;
-      size_t len = (b.end-b.start+1)*elm_size;
+  dst.reset(count(max_elm) * elm_size);
+  char* ptr = dst.data();
 
-      fenix_assert((ptr+len)-dst.data() <= dst.size());
-      fenix_assert(start+len <= src.size());
+  for (const auto b : BlockIter(bounded_regions(max_elm))) {
+    size_t start = b.start * elm_size;
+    size_t len   = (b.end - b.start + 1) * elm_size;
 
-      memcpy(ptr, src.data()+start, len);
-      ptr += len;
-   }
+    fenix_assert((ptr + len) - dst.data() <= dst.size());
+    fenix_assert(start + len <= src.size());
 
-   fenix_assert(ptr == dst.data()+dst.size());
+    memcpy(ptr, src.data() + start, len);
+    ptr += len;
+  }
+
+  fenix_assert(ptr == dst.data() + dst.size());
 }
 
 void DataSubset::deserialize_data(
-   size_t elm_size, const DataBuffer& src, DataBuffer& dst
+  size_t elm_size, const DataBuffer& src, DataBuffer& dst
 ) const {
-   fenix_assert(type == BasicSubset);
-   if(regions.empty()) return;
-   fenix_assert(dst.size()%elm_size==0);
+  fenix_assert(type == BasicSubset);
+  if (regions.empty()) return;
+  fenix_assert(dst.size() % elm_size == 0);
 
-   size_t max_elm = dst.size()/elm_size - 1;
-   if(max_elm == MAX){
-      max_elm = end();
-      fenix_assert(max_elm != MAX);
-      dst.resize((max_elm+1)*elm_size);
-   }
+  size_t max_elm = dst.size() / elm_size - 1;
+  if (max_elm == MAX) {
+    max_elm = end();
+    fenix_assert(max_elm != MAX);
+    dst.resize((max_elm + 1) * elm_size);
+  }
 
-   fenix_assert(src.size() == count(max_elm)*elm_size);
-   const char* ptr = src.data();
+  fenix_assert(src.size() == count(max_elm) * elm_size);
+  const char* ptr = src.data();
 
-   for(const auto& b : BlockIter(bounded_regions(max_elm))){
-      size_t start = b.start*elm_size;
-      size_t len = (b.end-b.start+1)*elm_size;
+  for (const auto& b : BlockIter(bounded_regions(max_elm))) {
+    size_t start = b.start * elm_size;
+    size_t len   = (b.end - b.start + 1) * elm_size;
 
-      fenix_assert((ptr+len)-src.data() <= src.size());
-      fenix_assert(start+len <= dst.size());
+    fenix_assert((ptr + len) - src.data() <= src.size());
+    fenix_assert(start + len <= dst.size());
 
-      memcpy(dst.data()+start, ptr, len);
-      ptr += len;
-   }
+    memcpy(dst.data() + start, ptr, len);
+    ptr += len;
+  }
 
-   fenix_assert(ptr == src.data()+src.size());
+  fenix_assert(ptr == src.data() + src.size());
 }
 
 void DataSubset::copy_data(
-   const size_t elm_size, const size_t src_len, const char* src, DataBuffer& dst
+  const size_t elm_size, const size_t src_len, const char* src, DataBuffer& dst
 ) const {
-   fenix_assert(type == BasicSubset);
-   if(regions.empty()) return;
-   fenix_assert(src_len != 0 || end() != MAX, 
-      "must specify either a maximum element count or provide a limited-bounds data subset");
+  fenix_assert(type == BasicSubset);
+  if (regions.empty()) return;
+  fenix_assert(
+    src_len != 0 || end() != MAX,
+    "must specify either a maximum element count or provide a limited-bounds "
+    "data subset"
+  );
 
-   size_t max_elm = src_len ? src_len-1 : end();
-   if(dst.size() < (max_elm+1)*elm_size) dst.resize((max_elm+1)*elm_size);
+  size_t max_elm = src_len ? src_len - 1 : end();
+  if (dst.size() < (max_elm + 1) * elm_size)
+    dst.resize((max_elm + 1) * elm_size);
 
-   for(const auto& b : BlockIter(bounded_regions(max_elm))){
-      size_t start = b.start*elm_size;
-      size_t len = (b.end-b.start+1)*elm_size;
+  for (const auto& b : BlockIter(bounded_regions(max_elm))) {
+    size_t start = b.start * elm_size;
+    size_t len   = (b.end - b.start + 1) * elm_size;
 
-      fenix_assert(src_len == 0 || (start+len)/elm_size <= src_len);
-      fenix_assert(start+len <= dst.size());
+    fenix_assert(src_len == 0 || (start + len) / elm_size <= src_len);
+    fenix_assert(start + len <= dst.size());
 
-      memcpy(dst.data()+start, src+start, len);
-   }
+    memcpy(dst.data() + start, src + start, len);
+  }
 }
 
 void DataSubset::copy_data(
-   const size_t elm_size, const DataBuffer& src, const size_t dst_len, char* dst
+  const size_t elm_size, const DataBuffer& src, const size_t dst_len, char* dst
 ) const {
-   fenix_assert(type == BasicSubset);
-   if(regions.empty()) return;
-   fenix_assert(dst_len != 0 || end() != MAX, 
-      "must specify either a maximum element count or provide a limited-bounds data subset");
+  fenix_assert(type == BasicSubset);
+  if (regions.empty()) return;
+  fenix_assert(
+    dst_len != 0 || end() != MAX,
+    "must specify either a maximum element count or provide a limited-bounds "
+    "data subset"
+  );
 
-   size_t max_elm = std::min(dst_len ? dst_len-1 : end(), src.size());
+  size_t max_elm = std::min(dst_len ? dst_len - 1 : end(), src.size());
 
-   for(const auto& b : BlockIter(bounded_regions(max_elm))){
-      size_t start = b.start*elm_size;
-      size_t len = (b.end-b.start+1)*elm_size;
+  for (const auto& b : BlockIter(bounded_regions(max_elm))) {
+    size_t start = b.start * elm_size;
+    size_t len   = (b.end - b.start + 1) * elm_size;
 
-      fenix_assert(dst_len == 0 || (start+len)/elm_size <= dst_len);
-      fenix_assert(start+len <= src.size());
+    fenix_assert(dst_len == 0 || (start + len) / elm_size <= dst_len);
+    fenix_assert(start + len <= src.size());
 
-      memcpy(dst+start, src.data()+start, len);
-   }
+    memcpy(dst + start, src.data() + start, len);
+  }
 }
 
 bool DataSubset::includes(size_t idx) const {
-   fenix_assert(type == BasicSubset);
-   return !bounded_regions(idx, idx).empty();
+  fenix_assert(type == BasicSubset);
+  return !bounded_regions(idx, idx).empty();
 }
 
 bool DataSubset::includes_all(size_t end) const {
-   fenix_assert(type == BasicSubset);
-   std::set<DataRegion> remaining = {DataRegion({0, end})};
+  fenix_assert(type == BasicSubset);
+  std::set<DataRegion> remaining = {DataRegion({0, end})};
 
-   for(const auto& r : regions){
-      if(r.start > end) break;
+  for (const auto& r : regions) {
+    if (r.start > end) break;
 
-      auto next = remaining.begin();
-      while(next != remaining.end()){
-         auto it = next++;
-         auto rem = *it;
+    auto next = remaining.begin();
+    while (next != remaining.end()) {
+      auto it  = next++;
+      auto rem = *it;
 
-         remaining.erase(it);
-         remaining.merge(rem - r);
-      }
-   }
-   
-   return remaining.empty();
+      remaining.erase(it);
+      remaining.merge(rem - r);
+    }
+  }
+
+  return remaining.empty();
 }
 
 std::string DataSubset::str() const {
-    if(type == PrestagedSubset) return "fenix::SUBSET_PRESTAGED";
-    std::string ret = "{";
-    for(const auto& r : regions) ret += r.str() + ", ";
-    if(!empty()){
-        ret.pop_back();
-        ret.pop_back();
-    }
-    ret += "}";
-    return ret;
+  if (type == PrestagedSubset) return "fenix::SUBSET_PRESTAGED";
+  std::string ret = "{";
+  for (const auto& r : regions) ret += r.str() + ", ";
+  if (!empty()) {
+    ret.pop_back();
+    ret.pop_back();
+  }
+  ret += "}";
+  return ret;
 }
 
 } // namespace fenix

--- a/src/fenix_process_recovery.cpp
+++ b/src/fenix_process_recovery.cpp
@@ -73,741 +73,759 @@ namespace fenix {
 static int __fenix_create_new_world();
 static int __fenix_repair_ranks();
 static void __fenix_test_MPI(MPI_Comm*, int*, ...);
-static int* __fenix_get_fail_ranks(int *, int, int);
+static int* __fenix_get_fail_ranks(int*, int, int);
 static int __fenix_spare_rank();
 static void spare_rank_loop();
 static void __fenix_finalize_spare();
 
-static int preinit(const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr){
-    fenix_rt.finalized = false;
+static int preinit(
+  const args::FenixInitArgs& args, jmp_buf* jump_env = nullptr
+) {
+  fenix_rt.finalized = false;
 
-    fenix_rt.world = (MPI_Comm *)malloc(sizeof(MPI_Comm));
-    MPI_Comm_dup(args.in_comm, fenix_rt.world);
-    
-    MPI_Comm_create_errhandler(__fenix_test_MPI, &fenix_rt.mpi_errhandler);
-    PMPI_Comm_set_errhandler(*fenix_rt.world, fenix_rt.mpi_errhandler);
+  fenix_rt.world = (MPI_Comm*)malloc(sizeof(MPI_Comm));
+  MPI_Comm_dup(args.in_comm, fenix_rt.world);
 
-    fenix_rt.user_world = args.out_comm;
-    fenix_rt.spare_ranks = args.spares;
-    fenix_rt.recover_environment = jump_env;
+  MPI_Comm_create_errhandler(__fenix_test_MPI, &fenix_rt.mpi_errhandler);
+  PMPI_Comm_set_errhandler(*fenix_rt.world, fenix_rt.mpi_errhandler);
 
-    fenix_rt.ret_role = args.role ? args.role : &fenix_rt.role;
-    fenix_rt.ret_error = args.err ? args.err : &fenix_rt.repair_result;
+  fenix_rt.user_world          = args.out_comm;
+  fenix_rt.spare_ranks         = args.spares;
+  fenix_rt.recover_environment = jump_env;
 
-    *fenix_rt.ret_role = fenix_rt.role;
-    *fenix_rt.ret_error = FENIX_SUCCESS;
+  fenix_rt.ret_role  = args.role ? args.role : &fenix_rt.role;
+  fenix_rt.ret_error = args.err ? args.err : &fenix_rt.repair_result;
 
-    fenix_rt.settings = fenix_default_settings;
-    if (fenix_rt.settings.resume == FENIX_RESUME_MODE_MAXCODE) {
-        fenix_rt.settings.resume = jump_env ? JUMP : THROW;
-    }
-    fenix_assert(
-        fenix_rt.settings.resume != JUMP || jump_env != nullptr,
-        "Must use Fenix_Init to use FENIX_RESUME_JUMP"
+  *fenix_rt.ret_role  = fenix_rt.role;
+  *fenix_rt.ret_error = FENIX_SUCCESS;
+
+  fenix_rt.settings = fenix_default_settings;
+  if (fenix_rt.settings.resume == FENIX_RESUME_MODE_MAXCODE) {
+    fenix_rt.settings.resume = jump_env ? JUMP : THROW;
+  }
+  fenix_assert(
+    fenix_rt.settings.resume != JUMP || jump_env != nullptr,
+    "Must use Fenix_Init to use FENIX_RESUME_JUMP"
+  );
+
+  MPI_Op_create((MPI_User_function*)__fenix_ranks_agree, 1, &fenix_rt.agree_op);
+
+  if (fenix_rt.spare_ranks >= __fenix_get_world_size(*fenix_rt.world)) {
+    debug_print(
+      "Fenix: <%d> spare ranks requested are unavailable\n",
+      fenix_rt.spare_ranks
     );
+  }
 
-    MPI_Op_create((MPI_User_function *) __fenix_ranks_agree, 1, &fenix_rt.agree_op);
+  fenix_rt.data_recovery = data::__fenix_data_recovery_init();
 
-    if (fenix_rt.spare_ranks >= __fenix_get_world_size(*fenix_rt.world)) {
-        debug_print("Fenix: <%d> spare ranks requested are unavailable\n",
-                    fenix_rt.spare_ranks);
+  /*****************************************************/
+  /* Note: fenix_rt.new_world is only valid for the   */
+  /*       active MPI ranks. Spare ranks do not        */
+  /*       allocate any communicator content with this.*/
+  /*       Any MPI calls in spare ranks with new_world */
+  /*       trigger an abort.                           */
+  /*****************************************************/
+
+  //Try to create new_world until success
+  while (__fenix_create_new_world());
+
+  if (__fenix_spare_rank() != 1) {
+    fenix_rt.num_initial_ranks = __fenix_get_world_size(fenix_rt.new_world);
+    if (fenix_rt.options.verbose == 0) {
+      verbose_print(
+        "rank: %d, role: %d, number_initial_ranks: %d\n",
+        __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role,
+        fenix_rt.num_initial_ranks
+      );
     }
 
-    fenix_rt.data_recovery = data::__fenix_data_recovery_init();
+  } else {
+    fenix_rt.num_initial_ranks = fenix_rt.spare_ranks;
 
-    /*****************************************************/
-    /* Note: fenix_rt.new_world is only valid for the   */
-    /*       active MPI ranks. Spare ranks do not        */
-    /*       allocate any communicator content with this.*/
-    /*       Any MPI calls in spare ranks with new_world */
-    /*       trigger an abort.                           */
-    /*****************************************************/
-
-    //Try to create new_world until success
-    while (__fenix_create_new_world());
-
-    if ( __fenix_spare_rank() != 1) {
-        fenix_rt.num_initial_ranks = __fenix_get_world_size(fenix_rt.new_world);
-        if (fenix_rt.options.verbose == 0) {
-            verbose_print("rank: %d, role: %d, number_initial_ranks: %d\n",
-                          __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role,
-                          fenix_rt.num_initial_ranks);
-        }
-
-    } else {
-        fenix_rt.num_initial_ranks = fenix_rt.spare_ranks;
-
-        if (fenix_rt.options.verbose == 0) {
-            verbose_print("rank: %d, role: %d, number_initial_ranks: %d\n",
-                          __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role,
-                          fenix_rt.num_initial_ranks);
-        }
+    if (fenix_rt.options.verbose == 0) {
+      verbose_print(
+        "rank: %d, role: %d, number_initial_ranks: %d\n",
+        __fenix_get_current_rank(*fenix_rt.world), fenix_rt.role,
+        fenix_rt.num_initial_ranks
+      );
     }
+  }
 
-    fenix_rt.fenix_init_flag = true;
+  fenix_rt.fenix_init_flag = true;
 
-    if(__fenix_spare_rank() == 1) spare_rank_loop();
-    
-    if(fenix_rt.role != FENIX_ROLE_RECOVERED_RANK) MPI_Comm_dup(fenix_rt.new_world, fenix_rt.user_world);
-    fenix_rt.user_world_exists = true;
+  if (__fenix_spare_rank() == 1) spare_rank_loop();
 
-    return fenix_rt.role;
+  if (fenix_rt.role != FENIX_ROLE_RECOVERED_RANK)
+    MPI_Comm_dup(fenix_rt.new_world, fenix_rt.user_world);
+  fenix_rt.user_world_exists = true;
+
+  return fenix_rt.role;
 }
 
-void init(const args::FenixInitArgs args){
+void init(const args::FenixInitArgs args) {
 
-    preinit(args);
-    __fenix_postinit();
+  preinit(args);
+  __fenix_postinit();
 }
 
-Fenix_Resume_mode get_resume_mode(const std::string_view& name){
-    if (name == "JUMP") {
-        return fenix::JUMP;
-    } else if (name == "RETURN") {
-        return fenix::RETURN;
-    } else if (name == "THROW") {
-        return fenix::THROW;
+int __fenix_spare_rank_within(MPI_Comm refcomm) {
+  int result         = -1;
+  int current_rank   = __fenix_get_current_rank(refcomm);
+  int new_world_size = __fenix_get_world_size(refcomm) - fenix_rt.spare_ranks;
+  if (current_rank >= new_world_size) {
+    if (fenix_rt.options.verbose == 6) {
+      verbose_print(
+        "current_rank: %d, new_world_size: %d\n", current_rank, new_world_size
+      );
     }
-    fatal_print("Unsupported FENIX_RESUME_MODE %s", name.data());
-}
-
-Fenix_Unhandled_mode get_unhandled_mode(const std::string_view& name){
-    if (name == "SILENT") {
-        return fenix::SILENT;
-    } else if (name == "PRINT") {
-        return fenix::PRINT;
-    } else if (name == "ABORT") {
-        return fenix::ABORT;
-    }
-    fatal_print("Unsupported FENIX_UNHANDLED_MODE %s", name.data());
-}
-
-int __fenix_spare_rank_within(MPI_Comm refcomm)
-{
-    int result = -1;
-    int current_rank = __fenix_get_current_rank(refcomm);
-    int new_world_size = __fenix_get_world_size(refcomm) - fenix_rt.spare_ranks;
-    if (current_rank >= new_world_size) {
-        if (fenix_rt.options.verbose == 6) {
-            verbose_print("current_rank: %d, new_world_size: %d\n", current_rank, new_world_size);
-        }
-        result = 1;
-    }
-    return result;
+    result = 1;
+  }
+  return result;
 }
 
 void spare_rank_loop() {
-    const bool yield_mode = get_option(SPARE_WAIT_MODE) == YIELD;
-    const bool sleep_mode = get_option(SPARE_WAIT_MODE) == SLEEP;
+  const bool yield_mode = get_option(SPARE_WAIT_MODE) == YIELD;
+  const bool sleep_mode = get_option(SPARE_WAIT_MODE) == SLEEP;
 
-    int provided_thread_level;
-    MPI_T_init_thread(MPI_THREAD_SINGLE, &provided_thread_level);
+  int provided_thread_level;
+  MPI_T_init_thread(MPI_THREAD_SINGLE, &provided_thread_level);
 
-    MPI_T_cvar_handle yield_cvar = MPI_T_CVAR_HANDLE_NULL;
-    bool old_yield_setting = false;
-    if (yield_mode) {
-        int idx, count;
-        int ret = MPI_T_cvar_get_index("mpi_yield_when_idle", &idx);
+  MPI_T_cvar_handle yield_cvar = MPI_T_CVAR_HANDLE_NULL;
+  bool old_yield_setting       = false;
+  if (yield_mode) {
+    int idx, count;
+    int ret = MPI_T_cvar_get_index("mpi_yield_when_idle", &idx);
+    if (ret == MPI_SUCCESS) {
+      MPI_T_cvar_handle_alloc(idx, NULL, &yield_cvar, &count);
+      MPI_T_cvar_read(yield_cvar, &old_yield_setting);
+      MPI_T_cvar_write(yield_cvar, &yield_mode);
+    }
+  }
+
+  while (__fenix_spare_rank() == 1) {
+    int a, ret = MPI_SUCCESS, msg_found = true;
+    MPI_Status mpi_status;
+    {
+      util::ScopedIgnoreAndReturn opts;
+      int progress_count = 0;
+      while (sleep_mode) {
+        ret = PMPI_Iprobe(
+          MPI_ANY_SOURCE, MPI_ANY_TAG, *fenix_rt.world, &msg_found, &mpi_status
+        );
         if (ret == MPI_SUCCESS) {
-            MPI_T_cvar_handle_alloc(idx, NULL, &yield_cvar, &count);
-            MPI_T_cvar_read(yield_cvar, &old_yield_setting);
-            MPI_T_cvar_write(yield_cvar, &yield_mode);
+          // Explicit check so older Open MPI versions still work
+          int is_revoked;
+          MPIX_Comm_is_revoked(*fenix_rt.world, &is_revoked);
+          if (is_revoked) ret = MPI_ERR_REVOKED;
         }
+
+        if (msg_found || ret != MPI_SUCCESS) break;
+        if (++progress_count >= 5) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          progress_count = 0;
+        }
+      }
+      if (ret == MPI_SUCCESS) {
+        ret = PMPI_Recv(
+          &a, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG, *fenix_rt.world,
+          &mpi_status
+        );
+      }
     }
-
-    while (__fenix_spare_rank() == 1) {
-        int a, ret = MPI_SUCCESS, msg_found = true;
-        MPI_Status mpi_status;
-        {
-            util::ScopedIgnoreAndReturn opts;
-            int progress_count = 0;
-            while (sleep_mode) {
-                ret = PMPI_Iprobe(
-                    MPI_ANY_SOURCE, MPI_ANY_TAG, *fenix_rt.world, &msg_found,
-                    &mpi_status
-                );
-                if (ret == MPI_SUCCESS) {
-                    // Explicit check so older Open MPI versions still work
-                    int is_revoked;
-                    MPIX_Comm_is_revoked(*fenix_rt.world, &is_revoked);
-                    if (is_revoked) ret = MPI_ERR_REVOKED;
-                }
-
-                if (msg_found || ret != MPI_SUCCESS) break;
-                if (++progress_count >= 5) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                    progress_count = 0;
-                }
-            }
-            if (ret == MPI_SUCCESS) {
-                ret = PMPI_Recv(
-                    &a, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG,
-                    *fenix_rt.world, &mpi_status
-                );
-            }
-        }
-        if (ret == MPI_SUCCESS) {
-            __fenix_finalize_spare();
-        } else if (ret == MPI_ERR_REVOKED) {
-            fenix_rt.repair_result = __fenix_repair_ranks();
-        } else {
-#ifdef MPICH_VERSION
-            MPIX_Comm_failure_ack(*fenix_rt.world);
-#else
-            MPIX_Comm_ack_failed(
-                *fenix_rt.world, __fenix_get_world_size(*fenix_rt.world), &a
-            );
-#endif
-        }
-    }
-
-    // Cleanup before exiting as a recovered rank
-    if (yield_cvar != MPI_T_CVAR_HANDLE_NULL) {
-        MPI_T_cvar_write(yield_cvar, &old_yield_setting);
-        MPI_T_cvar_handle_free(&yield_cvar);
-    }
-    MPI_T_finalize();
-
-    fenix_rt.role = FENIX_ROLE_RECOVERED_RANK;
-}
-
-int __fenix_create_new_world_from(MPI_Comm from_comm)
-{
-    int ret;
-
-    if ( __fenix_spare_rank_within(from_comm) == 1) {
-        int current_rank = __fenix_get_current_rank(from_comm);
-
-        /*************************************************************************/
-        /** MPI_UNDEFINED makes the new communicator "undefined" at spare ranks **/
-        /** This means no data is allocated at spare ranks                      **/
-        /** Use of the new communicator triggers the program to abort .         **/
-        /*************************************************************************/
-
-        if (fenix_rt.options.verbose == 1) {
-            verbose_print("rank: %d, role: %d\n", __fenix_get_current_rank(from_comm),
-                          fenix_rt.role);
-        }
-
-        ret = PMPI_Comm_split(from_comm, MPI_UNDEFINED, current_rank,
-                              &fenix_rt.new_world);
-        fenix_rt.new_world_exists = 0; //Should already be this
-
+    if (ret == MPI_SUCCESS) {
+      __fenix_finalize_spare();
+    } else if (ret == MPI_ERR_REVOKED) {
+      fenix_rt.repair_result = __fenix_repair_ranks();
     } else {
-
-        int current_rank = __fenix_get_current_rank(from_comm);
-
-        if (fenix_rt.options.verbose == 1) {
-            verbose_print("rank: %d, role: %d\n", __fenix_get_current_rank(from_comm),
-                          fenix_rt.role);
-        }
-
-        ret = PMPI_Comm_split(from_comm, 0, current_rank, &fenix_rt.new_world);
-        fenix_rt.new_world_exists = 1;
-        if (ret != MPI_SUCCESS){
-            fenix_rt.new_world_exists = 0;
-        }
-
+#ifdef MPICH_VERSION
+      MPIX_Comm_failure_ack(*fenix_rt.world);
+#else
+      MPIX_Comm_ack_failed(
+        *fenix_rt.world, __fenix_get_world_size(*fenix_rt.world), &a
+      );
+#endif
     }
-    return ret;
+  }
+
+  // Cleanup before exiting as a recovered rank
+  if (yield_cvar != MPI_T_CVAR_HANDLE_NULL) {
+    MPI_T_cvar_write(yield_cvar, &old_yield_setting);
+    MPI_T_cvar_handle_free(&yield_cvar);
+  }
+  MPI_T_finalize();
+
+  fenix_rt.role = FENIX_ROLE_RECOVERED_RANK;
 }
 
-int __fenix_create_new_world(){
-    return __fenix_create_new_world_from(*fenix_rt.world);
+int __fenix_create_new_world_from(MPI_Comm from_comm) {
+  int ret;
+
+  if (__fenix_spare_rank_within(from_comm) == 1) {
+    int current_rank = __fenix_get_current_rank(from_comm);
+
+    /*************************************************************************/
+    /** MPI_UNDEFINED makes the new communicator "undefined" at spare ranks **/
+    /** This means no data is allocated at spare ranks                      **/
+    /** Use of the new communicator triggers the program to abort .         **/
+    /*************************************************************************/
+
+    if (fenix_rt.options.verbose == 1) {
+      verbose_print(
+        "rank: %d, role: %d\n", __fenix_get_current_rank(from_comm),
+        fenix_rt.role
+      );
+    }
+
+    ret = PMPI_Comm_split(
+      from_comm, MPI_UNDEFINED, current_rank, &fenix_rt.new_world
+    );
+    fenix_rt.new_world_exists = 0; //Should already be this
+
+  } else {
+
+    int current_rank = __fenix_get_current_rank(from_comm);
+
+    if (fenix_rt.options.verbose == 1) {
+      verbose_print(
+        "rank: %d, role: %d\n", __fenix_get_current_rank(from_comm),
+        fenix_rt.role
+      );
+    }
+
+    ret = PMPI_Comm_split(from_comm, 0, current_rank, &fenix_rt.new_world);
+    fenix_rt.new_world_exists = 1;
+    if (ret != MPI_SUCCESS) {
+      fenix_rt.new_world_exists = 0;
+    }
+  }
+  return ret;
 }
 
-int __fenix_repair_ranks()
-{
-    util::ScopedIgnoreAndReturn scoped_opts;
-    util::ScopedActiveMlog active_mlog(FENIX_MLOG_NONE);
-    int recovery = scoped_opts.recovery.old;
-    if(recovery == NOOP) return FENIX_SUCCESS;
+int __fenix_create_new_world() {
+  return __fenix_create_new_world_from(*fenix_rt.world);
+}
 
-    /*********************************************************/
-    /* Do not forget comm_free for broken communicators      */
-    /*********************************************************/
-    int ret;
-    int survived_flag;
-    int *survivor_world;
-    int *fail_world;
-    int current_rank;
-    int survivor_world_size;
-    int world_size;
-    int fail_world_size;
-    int rt_code = FENIX_SUCCESS;
-    int repair_success = 0;
-    int num_try = 0;
-    int flag_g_world_freed = 0;
-    MPI_Comm world_without_failures, fixed_world;
+int __fenix_repair_ranks() {
+  util::ScopedIgnoreAndReturn scoped_opts;
+  util::ScopedActiveMlog active_mlog(FENIX_MLOG_NONE);
+  int recovery = scoped_opts.recovery.old;
+  if (recovery == NOOP) return FENIX_SUCCESS;
 
-    
-    /* current_rank means the global MPI rank before failure */
-    current_rank = __fenix_get_current_rank(*fenix_rt.world);
-    world_size = __fenix_get_world_size(*fenix_rt.world);
+  /*********************************************************/
+  /* Do not forget comm_free for broken communicators      */
+  /*********************************************************/
+  int ret;
+  int survived_flag;
+  int* survivor_world;
+  int* fail_world;
+  int current_rank;
+  int survivor_world_size;
+  int world_size;
+  int fail_world_size;
+  int rt_code            = FENIX_SUCCESS;
+  int repair_success     = 0;
+  int num_try            = 0;
+  int flag_g_world_freed = 0;
+  MPI_Comm world_without_failures, fixed_world;
 
-    //Double check that every process is here, not in some local error handling elsewhere.
-    //Assume that other locations will converge here.
-    if(__fenix_spare_rank() != 1){
-    	int location = FENIX_ERRHANDLER_LOC;
-    	do {
-	    location = FENIX_ERRHANDLER_LOC;
-	    MPIX_Comm_agree(*fenix_rt.user_world, &location);
-        } while(location != FENIX_ERRHANDLER_LOC);
+  /* current_rank means the global MPI rank before failure */
+  current_rank = __fenix_get_current_rank(*fenix_rt.world);
+  world_size   = __fenix_get_world_size(*fenix_rt.world);
+
+  //Double check that every process is here, not in some local error handling
+  //elsewhere. Assume that other locations will converge here.
+  if (__fenix_spare_rank() != 1) {
+    int location = FENIX_ERRHANDLER_LOC;
+    do {
+      location = FENIX_ERRHANDLER_LOC;
+      MPIX_Comm_agree(*fenix_rt.user_world, &location);
+    } while (location != FENIX_ERRHANDLER_LOC);
+  }
+
+  while (!repair_success) {
+    repair_success = 1;
+
+    ret = MPIX_Comm_shrink(*fenix_rt.world, &world_without_failures);
+    if (ret != MPI_SUCCESS) {
+      repair_success = 0;
+      goto END_LOOP;
     }
-    
-    while (!repair_success) {
-        repair_success = 1;
 
-        ret = MPIX_Comm_shrink(*fenix_rt.world, &world_without_failures);
-        if (ret != MPI_SUCCESS) {
-            repair_success = 0;
-            goto END_LOOP;
-        }
+    /*********************************************************/
+    /* Free up the storage for active process communicator   */
+    /*********************************************************/
+    if (__fenix_spare_rank() != 1) {
+      if (fenix_rt.new_world_exists) PMPI_Comm_free(&fenix_rt.new_world);
+      if (fenix_rt.user_world_exists) PMPI_Comm_free(fenix_rt.user_world);
+      fenix_rt.user_world_exists = 0;
+      fenix_rt.new_world_exists  = 0;
+    }
+    /*********************************************************/
+    /* Need closer look above                                */
+    /*********************************************************/
 
-        /*********************************************************/
-        /* Free up the storage for active process communicator   */
-        /*********************************************************/
-        if ( __fenix_spare_rank() != 1) {
-            if(fenix_rt.new_world_exists) PMPI_Comm_free(&fenix_rt.new_world);
-            if(fenix_rt.user_world_exists) PMPI_Comm_free(fenix_rt.user_world);
-            fenix_rt.user_world_exists = 0;
-            fenix_rt.new_world_exists = 0;
-        }
-        /*********************************************************/
-        /* Need closer look above                                */
-        /*********************************************************/
+    survivor_world_size      = __fenix_get_world_size(world_without_failures);
+    fenix_rt.fail_world_size = world_size - survivor_world_size;
 
-        survivor_world_size = __fenix_get_world_size(world_without_failures);
-        fenix_rt.fail_world_size = world_size - survivor_world_size;
+    if (fenix_rt.options.verbose == 2) {
+      verbose_print(
+        "current_rank: %d, role: %d, world_size: %d, fail_world_size: %d, "
+        "survivor_world_size: %d\n",
+        current_rank, fenix_rt.role, world_size, fenix_rt.fail_world_size,
+        survivor_world_size
+      );
+    }
+
+    if (fenix_rt.spare_ranks < fenix_rt.fail_world_size) {
+      /* Not enough spare ranks */
+
+      if (fenix_rt.options.verbose == 2) {
+        verbose_print(
+          "current_rank: %d, role: %d, spare_ranks: %d, fail_world_size: %d\n",
+          current_rank, fenix_rt.role, fenix_rt.spare_ranks,
+          fenix_rt.fail_world_size
+        );
+      }
+
+      if (recovery == SPAWN) {
+        debug_print("FENIX_RECOVERY_SPAWN is not supported\n");
+      } else {
+
+        rt_code = FENIX_WARNING_SPARE_RANKS_DEPLETED;
+
+        /***************************************/
+        /* Fill the ranks in increasing order  */
+        /***************************************/
+
+        int active_ranks;
+
+        survivor_world = (int*)s_malloc(survivor_world_size * sizeof(int));
+
+        ret = PMPI_Allgather(
+          &current_rank, 1, MPI_INT, survivor_world, 1, MPI_INT,
+          world_without_failures
+        );
 
         if (fenix_rt.options.verbose == 2) {
+          int index;
+          for (index = 0; index < survivor_world_size; index++) {
             verbose_print(
-                "current_rank: %d, role: %d, world_size: %d, fail_world_size: %d, survivor_world_size: %d\n",
-                current_rank, fenix_rt.role, world_size,
-                fenix_rt.fail_world_size, survivor_world_size);
+              "current_rank: %d, role: %d, survivor_world[%d]: %d\n",
+              current_rank, fenix_rt.role, index, survivor_world[index]
+            );
+          }
         }
 
-        if (fenix_rt.spare_ranks < fenix_rt.fail_world_size) {
-            /* Not enough spare ranks */
-
-            if (fenix_rt.options.verbose == 2) {
-                verbose_print(
-                    "current_rank: %d, role: %d, spare_ranks: %d, fail_world_size: %d\n",
-                    current_rank, fenix_rt.role, fenix_rt.spare_ranks,
-                    fenix_rt.fail_world_size);
-            }
-
-            if (recovery == SPAWN) {
-                debug_print("FENIX_RECOVERY_SPAWN is not supported\n");
-            } else {
-
-                rt_code = FENIX_WARNING_SPARE_RANKS_DEPLETED;
-
-                /***************************************/
-                /* Fill the ranks in increasing order  */
-                /***************************************/
-
-                int active_ranks;
-
-                survivor_world = (int *) s_malloc(survivor_world_size * sizeof(int));
-
-                ret = PMPI_Allgather(&current_rank, 1, MPI_INT, survivor_world, 1, MPI_INT,
-                                     world_without_failures);
-
-                if (fenix_rt.options.verbose == 2) {
-                    int index;
-                    for (index = 0; index < survivor_world_size; index++) {
-                        verbose_print("current_rank: %d, role: %d, survivor_world[%d]: %d\n",
-                                      current_rank, fenix_rt.role, index,
-                                      survivor_world[index]);
-                    }
-                }
-
-                 //if (ret != MPI_SUCCESS) { debug_print("MPI_Allgather. repair_ranks\n"); }
-                if (ret != MPI_SUCCESS) {
-                    repair_success = 0;
-                    if (ret == MPI_ERR_PROC_FAILED) {
-                        MPIX_Comm_revoke(world_without_failures);
-                    }
-                    MPI_Comm_free(&world_without_failures);
-                    free(survivor_world);
-                    goto END_LOOP;
-                }
-
-                survived_flag = 0;
-                if (fenix_rt.role == FENIX_ROLE_SURVIVOR_RANK) {
-                    survived_flag = 1;
-                }
-
-                ret = PMPI_Allreduce(&survived_flag, &fenix_rt.num_survivor_ranks, 1,
-                                     MPI_INT, MPI_SUM, world_without_failures);
-
-                //if (ret != MPI_SUCCESS) { debug_print("MPI_Allreduce. repair_ranks\n"); }
-                if (ret != MPI_SUCCESS) {
-                    repair_success = 0;
-                    if (ret == MPI_ERR_PROC_FAILED) {
-                        MPIX_Comm_revoke(world_without_failures);
-                    }
-                    MPI_Comm_free(&world_without_failures);
-                    free(survivor_world);
-                    goto END_LOOP;
-                }
-
-                fenix_rt.num_initial_ranks = 0;
-
-                /* recovered ranks must be the number of spare ranks */
-                fenix_rt.num_recovered_ranks = fenix_rt.fail_world_size;
-
-                if (fenix_rt.options.verbose == 2) {
-                    verbose_print("current_rank: %d, role: %d, recovered_ranks: %d\n",
-                                  current_rank, fenix_rt.role,
-                                  fenix_rt.num_recovered_ranks);
-                }
-
-                if(fenix_rt.role != FENIX_ROLE_INITIAL_RANK){
-                    free(fenix_rt.fail_world);
-                }
-                fenix_rt.fail_world = __fenix_get_fail_ranks(survivor_world, survivor_world_size,
-                                                    fenix_rt.fail_world_size);
-
-                if (fenix_rt.options.verbose == 2) {
-                    int index;
-                    for (index = 0; index < fenix_rt.fail_world_size; index++) {
-                        verbose_print("fail_world[%d]: %d\n", index, fenix_rt.fail_world[index]);
-                    }
-                }
-
-                free(survivor_world);
-
-                active_ranks = world_size - fenix_rt.spare_ranks;
-
-                if (fenix_rt.options.verbose == 2) {
-                    verbose_print("current_rank: %d, role: %d, active_ranks: %d\n",
-                                  current_rank, fenix_rt.role,
-                                  active_ranks);
-                }
-
-                /* Assign new rank for reordering */
-                if (current_rank >= active_ranks) { // reorder ranks
-                    int rank_offset = ((world_size - 1) - current_rank);
-
-                    for(int fail_i = 0; fail_i < fenix_rt.fail_world_size; fail_i++){
-                      if(fenix_rt.fail_world[fail_i] > current_rank) rank_offset--;
-                    }
-
-                    if (rank_offset < fenix_rt.fail_world_size) {
-                        if (fenix_rt.options.verbose == 11) {
-                            verbose_print("reorder ranks; current_rank: %d -> new_rank: %d\n",
-                                          current_rank, fenix_rt.fail_world[rank_offset]);
-                        }
-                        current_rank = fenix_rt.fail_world[rank_offset];
-                    }
-                }
-
-                /************************************/
-                /* Update the number of spare ranks */
-                /************************************/
-                fenix_rt.spare_ranks = 0;
-            }
-        } else {
-
-            int active_ranks;
-
-            survivor_world = (int *) s_malloc(survivor_world_size * sizeof(int));
-
-            ret = PMPI_Allgather(&current_rank, 1, MPI_INT, survivor_world, 1, MPI_INT,
-                                 world_without_failures);
-            if (ret != MPI_SUCCESS) {
-                repair_success = 0;
-                if (ret == MPI_ERR_PROC_FAILED) {
-                    MPIX_Comm_revoke(world_without_failures);
-                }
-                MPI_Comm_free(&world_without_failures);
-                free(survivor_world);
-                goto END_LOOP;
-            }
-
-            survived_flag = 0;
-            if (fenix_rt.role == FENIX_ROLE_SURVIVOR_RANK) {
-                survived_flag = 1;
-            }
-
-            ret = PMPI_Allreduce(&survived_flag, &fenix_rt.num_survivor_ranks, 1,
-                                 MPI_INT, MPI_SUM, world_without_failures);
-            if (ret != MPI_SUCCESS) {
-                repair_success = 0;
-                if (ret != MPI_ERR_PROC_FAILED) {
-                    MPIX_Comm_revoke(world_without_failures);
-                }
-                MPI_Comm_free(&world_without_failures);
-                free(survivor_world);
-                goto END_LOOP;
-            }
-
-
-            fenix_rt.num_initial_ranks = 0;
-            fenix_rt.num_recovered_ranks = fenix_rt.fail_world_size;
-            
-            if(fenix_rt.role != FENIX_ROLE_INITIAL_RANK){
-                free(fenix_rt.fail_world);
-            }
-
-            fenix_rt.fail_world = (int *) s_malloc(fenix_rt.fail_world_size * sizeof(int));
-            fenix_rt.fail_world = __fenix_get_fail_ranks(survivor_world, survivor_world_size, fenix_rt.fail_world_size);
-            free(survivor_world);
-
-            if (fenix_rt.options.verbose == 2) {
-                int index;
-                for (index = 0; index < fenix_rt.fail_world_size; index++) {
-                    verbose_print("fail_world[%d]: %d\n", index, fenix_rt.fail_world[index]);
-                }
-            }
-
-            active_ranks = world_size - fenix_rt.spare_ranks;
-
-            if (fenix_rt.options.verbose == 2) {
-                verbose_print("current_rank: %d, role: %d, active_ranks: %d\n",
-                              current_rank, fenix_rt.role, active_ranks);
-            }
-
-            if (current_rank >= active_ranks) { // reorder ranks
-                int rank_offset = ((world_size - 1) - current_rank);
-
-                for(int fail_i = 0; fail_i < fenix_rt.fail_world_size; fail_i++){
-                  if(fenix_rt.fail_world[fail_i] > current_rank) rank_offset--;
-                }
-
-                if (rank_offset < fenix_rt.fail_world_size) {
-                    if (fenix_rt.options.verbose == 2) {
-                        verbose_print("reorder ranks; current_rank: %d -> new_rank: %d (offset %d)\n",
-                                      current_rank, fenix_rt.fail_world[rank_offset], rank_offset);
-                    }
-                    current_rank = fenix_rt.fail_world[rank_offset];
-                }
-            }
-
-            /************************************/
-            /* Update the number of spare ranks */
-            /************************************/
-            fenix_rt.spare_ranks = fenix_rt.spare_ranks - fenix_rt.fail_world_size;
-            if (fenix_rt.options.verbose == 2) {
-                verbose_print("current_rank: %d, role: %d, spare_ranks: %d\n",
-                              current_rank, fenix_rt.role,
-                              fenix_rt.spare_ranks);
-            }
-        }
-
-        /*********************************************************/
-        /* Done with the global communicator                     */
-        /*********************************************************/
-
-        ret = PMPI_Comm_split(world_without_failures, 0, current_rank, &fixed_world);
-        
+        //if (ret != MPI_SUCCESS) { debug_print("MPI_Allgather.
+        //repair_ranks\n"); }
         if (ret != MPI_SUCCESS) {
-            repair_success = 0;
-            if (ret != MPI_ERR_PROC_FAILED) {
-                MPIX_Comm_revoke(world_without_failures);
-            }
-            MPI_Comm_free(&world_without_failures);
-            goto END_LOOP;
+          repair_success = 0;
+          if (ret == MPI_ERR_PROC_FAILED) {
+            MPIX_Comm_revoke(world_without_failures);
+          }
+          MPI_Comm_free(&world_without_failures);
+          free(survivor_world);
+          goto END_LOOP;
         }
 
+        survived_flag = 0;
+        if (fenix_rt.role == FENIX_ROLE_SURVIVOR_RANK) {
+          survived_flag = 1;
+        }
+
+        ret = PMPI_Allreduce(
+          &survived_flag, &fenix_rt.num_survivor_ranks, 1, MPI_INT, MPI_SUM,
+          world_without_failures
+        );
+
+        //if (ret != MPI_SUCCESS) { debug_print("MPI_Allreduce.
+        //repair_ranks\n"); }
+        if (ret != MPI_SUCCESS) {
+          repair_success = 0;
+          if (ret == MPI_ERR_PROC_FAILED) {
+            MPIX_Comm_revoke(world_without_failures);
+          }
+          MPI_Comm_free(&world_without_failures);
+          free(survivor_world);
+          goto END_LOOP;
+        }
+
+        fenix_rt.num_initial_ranks = 0;
+
+        /* recovered ranks must be the number of spare ranks */
+        fenix_rt.num_recovered_ranks = fenix_rt.fail_world_size;
+
+        if (fenix_rt.options.verbose == 2) {
+          verbose_print(
+            "current_rank: %d, role: %d, recovered_ranks: %d\n", current_rank,
+            fenix_rt.role, fenix_rt.num_recovered_ranks
+          );
+        }
+
+        if (fenix_rt.role != FENIX_ROLE_INITIAL_RANK) {
+          free(fenix_rt.fail_world);
+        }
+        fenix_rt.fail_world = __fenix_get_fail_ranks(
+          survivor_world, survivor_world_size, fenix_rt.fail_world_size
+        );
+
+        if (fenix_rt.options.verbose == 2) {
+          int index;
+          for (index = 0; index < fenix_rt.fail_world_size; index++) {
+            verbose_print(
+              "fail_world[%d]: %d\n", index, fenix_rt.fail_world[index]
+            );
+          }
+        }
+
+        free(survivor_world);
+
+        active_ranks = world_size - fenix_rt.spare_ranks;
+
+        if (fenix_rt.options.verbose == 2) {
+          verbose_print(
+            "current_rank: %d, role: %d, active_ranks: %d\n", current_rank,
+            fenix_rt.role, active_ranks
+          );
+        }
+
+        /* Assign new rank for reordering */
+        if (current_rank >= active_ranks) { // reorder ranks
+          int rank_offset = ((world_size - 1) - current_rank);
+
+          for (int fail_i = 0; fail_i < fenix_rt.fail_world_size; fail_i++) {
+            if (fenix_rt.fail_world[fail_i] > current_rank) rank_offset--;
+          }
+
+          if (rank_offset < fenix_rt.fail_world_size) {
+            if (fenix_rt.options.verbose == 11) {
+              verbose_print(
+                "reorder ranks; current_rank: %d -> new_rank: %d\n",
+                current_rank, fenix_rt.fail_world[rank_offset]
+              );
+            }
+            current_rank = fenix_rt.fail_world[rank_offset];
+          }
+        }
+
+        /************************************/
+        /* Update the number of spare ranks */
+        /************************************/
+        fenix_rt.spare_ranks = 0;
+      }
+    } else {
+
+      int active_ranks;
+
+      survivor_world = (int*)s_malloc(survivor_world_size * sizeof(int));
+
+      ret = PMPI_Allgather(
+        &current_rank, 1, MPI_INT, survivor_world, 1, MPI_INT,
+        world_without_failures
+      );
+      if (ret != MPI_SUCCESS) {
+        repair_success = 0;
+        if (ret == MPI_ERR_PROC_FAILED) {
+          MPIX_Comm_revoke(world_without_failures);
+        }
         MPI_Comm_free(&world_without_failures);
+        free(survivor_world);
+        goto END_LOOP;
+      }
 
-        ret = __fenix_create_new_world_from(fixed_world);
-        if(ret != MPI_SUCCESS){
-            repair_success = 0;
-            MPIX_Comm_revoke(fixed_world);
-            MPI_Comm_free(&fixed_world);
-            goto END_LOOP;
+      survived_flag = 0;
+      if (fenix_rt.role == FENIX_ROLE_SURVIVOR_RANK) {
+        survived_flag = 1;
+      }
+
+      ret = PMPI_Allreduce(
+        &survived_flag, &fenix_rt.num_survivor_ranks, 1, MPI_INT, MPI_SUM,
+        world_without_failures
+      );
+      if (ret != MPI_SUCCESS) {
+        repair_success = 0;
+        if (ret != MPI_ERR_PROC_FAILED) {
+          MPIX_Comm_revoke(world_without_failures);
+        }
+        MPI_Comm_free(&world_without_failures);
+        free(survivor_world);
+        goto END_LOOP;
+      }
+
+      fenix_rt.num_initial_ranks   = 0;
+      fenix_rt.num_recovered_ranks = fenix_rt.fail_world_size;
+
+      if (fenix_rt.role != FENIX_ROLE_INITIAL_RANK) {
+        free(fenix_rt.fail_world);
+      }
+
+      fenix_rt.fail_world =
+        (int*)s_malloc(fenix_rt.fail_world_size * sizeof(int));
+      fenix_rt.fail_world = __fenix_get_fail_ranks(
+        survivor_world, survivor_world_size, fenix_rt.fail_world_size
+      );
+      free(survivor_world);
+
+      if (fenix_rt.options.verbose == 2) {
+        int index;
+        for (index = 0; index < fenix_rt.fail_world_size; index++) {
+          verbose_print(
+            "fail_world[%d]: %d\n", index, fenix_rt.fail_world[index]
+          );
+        }
+      }
+
+      active_ranks = world_size - fenix_rt.spare_ranks;
+
+      if (fenix_rt.options.verbose == 2) {
+        verbose_print(
+          "current_rank: %d, role: %d, active_ranks: %d\n", current_rank,
+          fenix_rt.role, active_ranks
+        );
+      }
+
+      if (current_rank >= active_ranks) { // reorder ranks
+        int rank_offset = ((world_size - 1) - current_rank);
+
+        for (int fail_i = 0; fail_i < fenix_rt.fail_world_size; fail_i++) {
+          if (fenix_rt.fail_world[fail_i] > current_rank) rank_offset--;
         }
 
-        if(__fenix_spare_rank_within(fixed_world) == -1){
-            ret = MPI_Comm_dup(fenix_rt.new_world, fenix_rt.user_world);
-            if (ret != MPI_SUCCESS){
-                repair_success = 0;
-                MPIX_Comm_revoke(fixed_world);
-                MPI_Comm_free(&fixed_world);
-                goto END_LOOP;
-            }
-            fenix_rt.user_world_exists = 1;
+        if (rank_offset < fenix_rt.fail_world_size) {
+          if (fenix_rt.options.verbose == 2) {
+            verbose_print(
+              "reorder ranks; current_rank: %d -> new_rank: %d (offset %d)\n",
+              current_rank, fenix_rt.fail_world[rank_offset], rank_offset
+            );
+          }
+          current_rank = fenix_rt.fail_world[rank_offset];
         }
-        
-        ret = PMPI_Barrier(fixed_world);
-        if (ret != MPI_SUCCESS) {
-            repair_success = 0;
-            MPIX_Comm_revoke(fixed_world);
-            MPI_Comm_free(&fixed_world);
-            goto END_LOOP;
-        }
+      }
 
-    END_LOOP:
-        num_try++;
+      /************************************/
+      /* Update the number of spare ranks */
+      /************************************/
+      fenix_rt.spare_ranks = fenix_rt.spare_ranks - fenix_rt.fail_world_size;
+      if (fenix_rt.options.verbose == 2) {
+        verbose_print(
+          "current_rank: %d, role: %d, spare_ranks: %d\n", current_rank,
+          fenix_rt.role, fenix_rt.spare_ranks
+        );
+      }
     }
 
-    *fenix_rt.world = fixed_world;
-    return rt_code;
-}
+    /*********************************************************/
+    /* Done with the global communicator                     */
+    /*********************************************************/
 
-int* __fenix_get_fail_ranks(int *survivor_world, int survivor_world_size, int fail_world_size)
-{
-    qsort(survivor_world, survivor_world_size, sizeof(int), __fenix_comparator);
-    int failed_pos = 0;
-    
-    int *fail_ranks = (int *)calloc(fail_world_size, sizeof(int));
+    ret =
+      PMPI_Comm_split(world_without_failures, 0, current_rank, &fixed_world);
 
-    int i;
-    for (i = 0; i < survivor_world_size + fail_world_size; i++) {
-        if (__fenix_binary_search(survivor_world, survivor_world_size, i) != 1) {
-            if (fenix_rt.options.verbose == 14) {
-                verbose_print("fail_rank: %d, fail_ranks[%d]: %d\n", i, failed_pos,
-                              fail_ranks[failed_pos++]);
-            }
-            fail_ranks[failed_pos++] = i;
-        }
+    if (ret != MPI_SUCCESS) {
+      repair_success = 0;
+      if (ret != MPI_ERR_PROC_FAILED) {
+        MPIX_Comm_revoke(world_without_failures);
+      }
+      MPI_Comm_free(&world_without_failures);
+      goto END_LOOP;
     }
-    return fail_ranks;
+
+    MPI_Comm_free(&world_without_failures);
+
+    ret = __fenix_create_new_world_from(fixed_world);
+    if (ret != MPI_SUCCESS) {
+      repair_success = 0;
+      MPIX_Comm_revoke(fixed_world);
+      MPI_Comm_free(&fixed_world);
+      goto END_LOOP;
+    }
+
+    if (__fenix_spare_rank_within(fixed_world) == -1) {
+      ret = MPI_Comm_dup(fenix_rt.new_world, fenix_rt.user_world);
+      if (ret != MPI_SUCCESS) {
+        repair_success = 0;
+        MPIX_Comm_revoke(fixed_world);
+        MPI_Comm_free(&fixed_world);
+        goto END_LOOP;
+      }
+      fenix_rt.user_world_exists = 1;
+    }
+
+    ret = PMPI_Barrier(fixed_world);
+    if (ret != MPI_SUCCESS) {
+      repair_success = 0;
+      MPIX_Comm_revoke(fixed_world);
+      MPI_Comm_free(&fixed_world);
+      goto END_LOOP;
+    }
+
+  END_LOOP:
+    num_try++;
+  }
+
+  *fenix_rt.world = fixed_world;
+  return rt_code;
 }
 
-int __fenix_spare_rank(){
-    return __fenix_spare_rank_within(*fenix_rt.world);
+int* __fenix_get_fail_ranks(
+  int* survivor_world, int survivor_world_size, int fail_world_size
+) {
+  qsort(survivor_world, survivor_world_size, sizeof(int), __fenix_comparator);
+  int failed_pos = 0;
+
+  int* fail_ranks = (int*)calloc(fail_world_size, sizeof(int));
+
+  int i;
+  for (i = 0; i < survivor_world_size + fail_world_size; i++) {
+    if (__fenix_binary_search(survivor_world, survivor_world_size, i) != 1) {
+      if (fenix_rt.options.verbose == 14) {
+        verbose_print(
+          "fail_rank: %d, fail_ranks[%d]: %d\n", i, failed_pos,
+          fail_ranks[failed_pos++]
+        );
+      }
+      fail_ranks[failed_pos++] = i;
+    }
+  }
+  return fail_ranks;
 }
+
+int __fenix_spare_rank() { return __fenix_spare_rank_within(*fenix_rt.world); }
 
 int detect_failures(bool do_recovery) {
 #ifdef FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS
-    // Special handling b/c we're doing things outside the API macro
-    if (!initialized()) return FENIX_ERROR_UNINITIALIZED;
+  // Special handling b/c we're doing things outside the API macro
+  if (!initialized()) return FENIX_ERROR_UNINITIALIZED;
 #endif
-    // Create the IgnoreAndReturn scoped option if recovery is disabled.
-    // Doing this outside of the API macro so the function behaves as if the
-    // user had these settings on.
-    std::optional<util::ScopedIgnoreAndReturn> scoped_opts;
-    if (!do_recovery) scoped_opts.emplace();
-    const bool must_return = get_option(RESUME_MODE) == RETURN;
+  // Create the IgnoreAndReturn scoped option if recovery is disabled.
+  // Doing this outside of the API macro so the function behaves as if the
+  // user had these settings on.
+  std::optional<util::ScopedIgnoreAndReturn> scoped_opts;
+  if (!do_recovery) scoped_opts.emplace();
+  const bool must_return = get_option(RESUME_MODE) == RETURN;
 
-    FENIX_CPP_API_BEGIN
-    util::ScopedActiveMlog scoped_mlog(FENIX_MLOG_NONE);
-    const bool inline_recovery = scoped_mlog.old_inline_recovery;
+  FENIX_CPP_API_BEGIN
+  util::ScopedActiveMlog scoped_mlog(FENIX_MLOG_NONE);
+  const bool inline_recovery = scoped_mlog.old_inline_recovery;
 
-    while (true) {
-        try {
-            int flag;
-            int ret = MPI_Test(
-                &fenix_rt.check_failures_req, &flag, MPI_STATUS_IGNORE
-            );
-            fenix_assert(!flag, "DETECT_FAILURES_TAG should never be used");
-            if (ret == MPI_SUCCESS) return FENIX_SUCCESS;
-            else if (!inline_recovery) return FENIX_ERROR_PROCESS_FAILURE;
-        } catch (const CommException& e) {
-            if (!inline_recovery) {
-                if (must_return) return FENIX_ERROR_PROCESS_FAILURE;
-                else throw;
-            }
-        }
+  while (true) {
+    try {
+      int flag;
+      int ret =
+        MPI_Test(&fenix_rt.check_failures_req, &flag, MPI_STATUS_IGNORE);
+      fenix_assert(!flag, "DETECT_FAILURES_TAG should never be used");
+      if (ret == MPI_SUCCESS) return FENIX_SUCCESS;
+      else if (!inline_recovery) return FENIX_ERROR_PROCESS_FAILURE;
+    } catch (const CommException& e) {
+      if (!inline_recovery) {
+        if (must_return) return FENIX_ERROR_PROCESS_FAILURE;
+        else throw;
+      }
     }
-    FENIX_CPP_API_END
+  }
+  FENIX_CPP_API_END
 }
 
-void __fenix_finalize_spare()
-{
-    fenix_rt.fenix_init_flag = false;
-    int unused;
+void __fenix_finalize_spare() {
+  fenix_rt.fenix_init_flag = false;
+  int unused;
 
 #ifdef MPICH_VERSION
-    MPIX_Comm_agree(*fenix_rt.world, &unused);
+  MPIX_Comm_agree(*fenix_rt.world, &unused);
 #else
-    MPI_Request agree_req, recv_req = MPI_REQUEST_NULL;
+  MPI_Request agree_req, recv_req = MPI_REQUEST_NULL;
 
-    MPIX_Comm_iagree(*fenix_rt.world, &unused, &agree_req);
-    while(true){
-        int completed = 0;
-        MPI_Test(&agree_req, &completed, MPI_STATUS_IGNORE);
-        if(completed) break;
+  MPIX_Comm_iagree(*fenix_rt.world, &unused, &agree_req);
+  while (true) {
+    int completed = 0;
+    MPI_Test(&agree_req, &completed, MPI_STATUS_IGNORE);
+    if (completed) break;
 
-        int ret = MPI_Test(&recv_req, &completed, MPI_STATUS_IGNORE);
-        if(completed){
-            //We may get duplicate messages informing us to exit
-            MPI_Irecv(&unused, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG, *fenix_rt.world, &recv_req);
-        }
-        if(ret != MPI_SUCCESS){
-            MPIX_Comm_ack_failed(*fenix_rt.world, __fenix_get_world_size(*fenix_rt.world), &unused);
-        }
+    int ret = MPI_Test(&recv_req, &completed, MPI_STATUS_IGNORE);
+    if (completed) {
+      //We may get duplicate messages informing us to exit
+      MPI_Irecv(
+        &unused, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG, *fenix_rt.world,
+        &recv_req
+      );
     }
+    if (ret != MPI_SUCCESS) {
+      MPIX_Comm_ack_failed(
+        *fenix_rt.world, __fenix_get_world_size(*fenix_rt.world), &unused
+      );
+    }
+  }
 
-    if(recv_req != MPI_REQUEST_NULL) MPI_Cancel(&recv_req);
+  if (recv_req != MPI_REQUEST_NULL) MPI_Cancel(&recv_req);
 #endif
- 
-    MPI_Op_free(&fenix_rt.agree_op);
-    MPI_Comm_set_errhandler(*fenix_rt.world, MPI_ERRORS_ARE_FATAL);
-    MPI_Comm_free(fenix_rt.world);
 
-    /* Free data recovery interface */
-    __fenix_data_recovery_destroy( fenix_rt.data_recovery );
+  MPI_Op_free(&fenix_rt.agree_op);
+  MPI_Comm_set_errhandler(*fenix_rt.world, MPI_ERRORS_ARE_FATAL);
+  MPI_Comm_free(fenix_rt.world);
 
-    /* Free up any C++ data structures, reset default variables */
-    fenix_rt = {};
+  /* Free data recovery interface */
+  __fenix_data_recovery_destroy(fenix_rt.data_recovery);
 
-    /* Future version do not close MPI. Jump to where Fenix_Finalize is called. */
-    MPI_Finalize();
-    exit(0);
+  /* Free up any C++ data structures, reset default variables */
+  fenix_rt = {};
+
+  /* Future version do not close MPI. Jump to where Fenix_Finalize is called. */
+  MPI_Finalize();
+  exit(0);
 }
 
-void __fenix_test_MPI(MPI_Comm *pcomm, int *pret, ...)
-{
-    util::ScopedActiveMlog active_mlog(FENIX_MLOG_NONE);
-    fenix_rt.mpi_fail_code = *pret;
+void __fenix_test_MPI(MPI_Comm* pcomm, int* pret, ...) {
+  util::ScopedActiveMlog active_mlog(FENIX_MLOG_NONE);
+  fenix_rt.mpi_fail_code = *pret;
 
-    if(!fenix_rt.fenix_init_flag) return;
+  if (!fenix_rt.fenix_init_flag) return;
 
-    constexpr bool throw_new = true;
+  constexpr bool throw_new = true;
 
-    switch (fenix_rt.mpi_fail_code) {
-    case MPI_ERR_PROC_FAILED_PENDING:
-    case MPI_ERR_PROC_FAILED:
-    case MPI_ERR_REVOKED:
-        // This is an error type handled by Fenix
+  switch (fenix_rt.mpi_fail_code) {
+  case MPI_ERR_PROC_FAILED_PENDING:
+  case MPI_ERR_PROC_FAILED:
+  case MPI_ERR_REVOKED:
+    // This is an error type handled by Fenix
 
-        // Skip to resume if recovery mode is IGNORE
-        if(fenix_rt.settings.recovery == IGNORE) {
-            util::resume_application(throw_new);
-            return;
-        }
-
-        MPIX_Comm_revoke(*fenix_rt.world);
-        MPIX_Comm_revoke(fenix_rt.new_world);
-        if(fenix_rt.user_world_exists) MPIX_Comm_revoke(*fenix_rt.user_world);
-
-        callback_invoke_all(fenix::PRE_RECOVERY);
-        fenix_rt.repair_result = __fenix_repair_ranks();
-
-        fenix_rt.role = FENIX_ROLE_SURVIVOR_RANK;
-        __fenix_postinit();
-
-        util::resume_application(throw_new);
-        break;
-
-    default:
-        // This is an error type not handled by Fenix
-        std::string errstr = util::mpi_error_string(fenix_rt.mpi_fail_code);
-        switch (fenix_rt.settings.unhandled) {
-        case ABORT:
-            fprintf(stderr, "UNHANDLED ERR: %s\n", errstr.c_str());
-            MPI_Abort(*fenix_rt.world, 1);
-            break;
-        case PRINT:
-            fprintf(stderr, "UNHANDLED ERR: %s\n", errstr.c_str());
-            break;
-        case SILENT:
-            break;
-        default:
-            printf(
-                "Fenix internal error: Unknown unhandled mode %d\n",
-                fenix_rt.settings.unhandled
-            );
-            assert(false);
-            break;
-        }
+    // Skip to resume if recovery mode is IGNORE
+    if (fenix_rt.settings.recovery == IGNORE) {
+      util::resume_application(throw_new);
+      return;
     }
+
+    MPIX_Comm_revoke(*fenix_rt.world);
+    MPIX_Comm_revoke(fenix_rt.new_world);
+    if (fenix_rt.user_world_exists) MPIX_Comm_revoke(*fenix_rt.user_world);
+
+    callback_invoke_all(fenix::PRE_RECOVERY);
+    fenix_rt.repair_result = __fenix_repair_ranks();
+
+    fenix_rt.role = FENIX_ROLE_SURVIVOR_RANK;
+    __fenix_postinit();
+
+    util::resume_application(throw_new);
+    break;
+
+  default:
+    // This is an error type not handled by Fenix
+    std::string errstr = util::mpi_error_string(fenix_rt.mpi_fail_code);
+    switch (fenix_rt.settings.unhandled) {
+    case ABORT:
+      fprintf(stderr, "UNHANDLED ERR: %s\n", errstr.c_str());
+      MPI_Abort(*fenix_rt.world, 1);
+      break;
+    case PRINT:
+      fprintf(stderr, "UNHANDLED ERR: %s\n", errstr.c_str());
+      break;
+    case SILENT:
+      break;
+    default:
+      fatal_print("Unknown unhandled mode %d\n", fenix_rt.settings.unhandled);
+      break;
+    }
+  }
 }
 
 int comm_revoke(MPI_Comm comm) { return MPIX_Comm_revoke(comm); }
@@ -817,126 +835,132 @@ int comm_revoke(MPI_Comm comm) { return MPIX_Comm_revoke(comm); }
 using namespace fenix;
 
 int __fenix_preinit(
-    int *role, MPI_Comm comm, MPI_Comm *new_comm, int *argc, char ***argv,
-    int spare_ranks, int *error, jmp_buf *jump_env
+  int* role, MPI_Comm comm, MPI_Comm* new_comm, int* argc, char*** argv,
+  int spare_ranks, int* error, jmp_buf* jump_env
 ) {
-    args::FenixInitArgs args;
-    args.role = role;
-    args.in_comm = comm;
-    args.out_comm = new_comm;
-    args.argc = argc;
-    args.argv = argv;
-    args.spares = spare_ranks;
-    args.err = error;
-    return preinit(args, jump_env);
+  args::FenixInitArgs args;
+  args.role     = role;
+  args.in_comm  = comm;
+  args.out_comm = new_comm;
+  args.argc     = argc;
+  args.argv     = argv;
+  args.spares   = spare_ranks;
+  args.err      = error;
+  return preinit(args, jump_env);
 }
 
-void __fenix_postinit()
-{
-    util::ScopedActiveMlog active_mlog(FENIX_MLOG_NONE);
-    *fenix_rt.ret_role = fenix_rt.role;
-    *fenix_rt.ret_error = fenix_rt.repair_result;
+void __fenix_postinit() {
+  util::ScopedActiveMlog active_mlog(FENIX_MLOG_NONE);
+  *fenix_rt.ret_role  = fenix_rt.role;
+  *fenix_rt.ret_error = fenix_rt.repair_result;
 
-    if(fenix_rt.new_world_exists){
-        //Set up dummy irecv to use for checking for failures.
-        MPI_Irecv(&fenix_rt.dummy_recv_buffer, 1, MPI_INT, MPI_ANY_SOURCE,
-                  tags::DETECT_FAILURES_TAG, fenix_rt.new_world,
-                  &fenix_rt.check_failures_req);
-    }
+  if (fenix_rt.new_world_exists) {
+    //Set up dummy irecv to use for checking for failures.
+    MPI_Irecv(
+      &fenix_rt.dummy_recv_buffer, 1, MPI_INT, MPI_ANY_SOURCE,
+      tags::DETECT_FAILURES_TAG, fenix_rt.new_world,
+      &fenix_rt.check_failures_req
+    );
+  }
 
-    if(fenix_rt.role != FENIX_ROLE_INITIAL_RANK) {
-        callback_invoke_all();
-        if (fenix_rt.settings.mlog_recovery == INLINE_AUTOSYNC) {
-            for (int mlog_id : fenix_rt.mlog_order) {
-                mlog::sync(mlog_id, FENIX_MLOG_CONTINUE);
-            }
-        }
+  if (fenix_rt.role != FENIX_ROLE_INITIAL_RANK) {
+    callback_invoke_all();
+    if (fenix_rt.settings.mlog_recovery == INLINE_AUTOSYNC) {
+      for (int mlog_id : fenix_rt.mlog_order) {
+        mlog::sync(mlog_id, FENIX_MLOG_CONTINUE);
+      }
     }
+  }
 
-    if (fenix_rt.options.verbose == 9) {
-        verbose_print("After barrier. current_rank: %d, role: %d\n", __fenix_get_current_rank(fenix_rt.new_world),
-                      fenix_rt.role);
-    }
+  if (fenix_rt.options.verbose == 9) {
+    verbose_print(
+      "After barrier. current_rank: %d, role: %d\n",
+      __fenix_get_current_rank(fenix_rt.new_world), fenix_rt.role
+    );
+  }
 }
 
 int Fenix_Finalize() {
-    FENIX_C_API_BEGIN
-    util::ScopedActiveMlog scoped_mlog(FENIX_MLOG_NONE);
-    bool inline_recovery = scoped_mlog.old_inline_recovery;
+  FENIX_C_API_BEGIN
+  util::ScopedActiveMlog scoped_mlog(FENIX_MLOG_NONE);
+  bool inline_recovery = scoped_mlog.old_inline_recovery;
 
-    int location = FENIX_FINALIZE_LOC;
-    do {
-        MPIX_Comm_agree(*fenix_rt.user_world, &location);
-        if(location != FENIX_FINALIZE_LOC){
-            //Some ranks are in error recovery, so trigger error handling.
-            MPIX_Comm_revoke(*fenix_rt.user_world);
-            if (inline_recovery) {
-                // If we are doing inline recovery for this function, set errors
-                // to return so we can just keep retrying this barrier.
-                util::ScopedOption(FENIX_RESUME_MODE, RETURN);
-                MPI_Barrier(*fenix_rt.user_world);
-            } else {
-                MPI_Barrier(*fenix_rt.user_world);
-            }
-        }
-    } while (location != FENIX_FINALIZE_LOC);
+  int location = FENIX_FINALIZE_LOC;
+  do {
+    MPIX_Comm_agree(*fenix_rt.user_world, &location);
+    if (location != FENIX_FINALIZE_LOC) {
+      //Some ranks are in error recovery, so trigger error handling.
+      MPIX_Comm_revoke(*fenix_rt.user_world);
+      if (inline_recovery) {
+        // If we are doing inline recovery for this function, set errors
+        // to return so we can just keep retrying this barrier.
+        util::ScopedOption(FENIX_RESUME_MODE, RETURN);
+        MPI_Barrier(*fenix_rt.user_world);
+      } else {
+        MPI_Barrier(*fenix_rt.user_world);
+      }
+    }
+  } while (location != FENIX_FINALIZE_LOC);
 
-    int first_spare_rank = __fenix_get_world_size(*fenix_rt.user_world);
-    int last_spare_rank = __fenix_get_world_size(*fenix_rt.world) - 1;
+  int first_spare_rank = __fenix_get_world_size(*fenix_rt.user_world);
+  int last_spare_rank  = __fenix_get_world_size(*fenix_rt.world) - 1;
 
-    //If we've reached here, we will finalize regardless of further errors.
-    fenix_rt.settings.recovery = IGNORE;
-    fenix_rt.settings.resume = RETURN;
-    while(!fenix_rt.finalized){
-        int user_rank = __fenix_get_current_rank(*fenix_rt.user_world);
+  //If we've reached here, we will finalize regardless of further errors.
+  fenix_rt.settings.recovery = IGNORE;
+  fenix_rt.settings.resume   = RETURN;
+  while (!fenix_rt.finalized) {
+    int user_rank = __fenix_get_current_rank(*fenix_rt.user_world);
 
-        if (user_rank == 0) {
-            for (int i = first_spare_rank; i <= last_spare_rank; i++) {
-                //We don't care if a spare failed, ignore return value
-                int unused;
-                MPI_Request req;
-                MPI_Isend(&unused, 1, MPI_INT, i, 1, *fenix_rt.world, &req);
-                MPI_Request_free(&req);
-            }
-        }
-
-        //We need to confirm that rank 0 didn't fail, since it could have
-        //failed before notifying some spares to leave.
-        int need_retry = user_rank == 0 ? 0 : 1;
-        MPIX_Comm_agree(*fenix_rt.user_world, &need_retry);
-        if(need_retry == 1){
-            //Rank 0 didn't contribute, so we need to retry.
-            MPIX_Comm_shrink(*fenix_rt.user_world, fenix_rt.user_world);
-            continue;
-        } else {
-            //If rank 0 did contribute, we know sends made it, and regardless
-            //of any other failures we finalize.
-            fenix_rt.finalized = true;
-        }
+    if (user_rank == 0) {
+      for (int i = first_spare_rank; i <= last_spare_rank; i++) {
+        //We don't care if a spare failed, ignore return value
+        int unused;
+        MPI_Request req;
+        MPI_Isend(&unused, 1, MPI_INT, i, 1, *fenix_rt.world, &req);
+        MPI_Request_free(&req);
+      }
     }
 
-    //Now we do one last agree w/ the spares to let them know they can actually
-    //finalize
-    int unused;
-    MPIX_Comm_agree(*fenix_rt.world, &unused);
-
-
-    MPI_Op_free( &fenix_rt.agree_op );
-    MPI_Comm_set_errhandler( *fenix_rt.world, MPI_ERRORS_ARE_FATAL );
-    MPI_Comm_free( fenix_rt.world );
-    free(fenix_rt.world);
-    if(fenix_rt.new_world_exists) MPI_Comm_free( &fenix_rt.new_world ); //It should, but just in case. Won't update because trying to free it again ought to generate an error anyway.
-
-    if(fenix_rt.role != FENIX_ROLE_INITIAL_RANK){
-        free(fenix_rt.fail_world);
+    //We need to confirm that rank 0 didn't fail, since it could have
+    //failed before notifying some spares to leave.
+    int need_retry = user_rank == 0 ? 0 : 1;
+    MPIX_Comm_agree(*fenix_rt.user_world, &need_retry);
+    if (need_retry == 1) {
+      //Rank 0 didn't contribute, so we need to retry.
+      MPIX_Comm_shrink(*fenix_rt.user_world, fenix_rt.user_world);
+      continue;
+    } else {
+      //If rank 0 did contribute, we know sends made it, and regardless
+      //of any other failures we finalize.
+      fenix_rt.finalized = true;
     }
+  }
 
-    /* Free data recovery interface */
-    __fenix_data_recovery_destroy( fenix_rt.data_recovery );
+  //Now we do one last agree w/ the spares to let them know they can actually
+  //finalize
+  int unused;
+  MPIX_Comm_agree(*fenix_rt.world, &unused);
 
-    /* Free up any C++ data structures, reset default variables */
-    fenix_rt = {};
-    fenix_rt.finalized = true;
-    return FENIX_SUCCESS;
-    FENIX_C_API_END
+  MPI_Op_free(&fenix_rt.agree_op);
+  MPI_Comm_set_errhandler(*fenix_rt.world, MPI_ERRORS_ARE_FATAL);
+  MPI_Comm_free(fenix_rt.world);
+  free(fenix_rt.world);
+  if (fenix_rt.new_world_exists) {
+    //It should exit, but just in case. Won't update because trying to free it
+    //again ought to generate an error anyway.
+    MPI_Comm_free(&fenix_rt.new_world);
+  }
+
+  if (fenix_rt.role != FENIX_ROLE_INITIAL_RANK) {
+    free(fenix_rt.fail_world);
+  }
+
+  /* Free data recovery interface */
+  __fenix_data_recovery_destroy(fenix_rt.data_recovery);
+
+  /* Free up any C++ data structures, reset default variables */
+  fenix_rt           = {};
+  fenix_rt.finalized = true;
+  return FENIX_SUCCESS;
+  FENIX_C_API_END
 }

--- a/src/logging/msg_log.cpp
+++ b/src/logging/msg_log.cpp
@@ -78,10 +78,10 @@ void write(std::ostream& s, const MPI_Datatype& d) {
 void write(std::ostream& s, const MPI_Op& o) { write<int>(s, mpi_ops.find(o)); }
 void read(std::istream& s, MPI_Datatype& d) {
   int id = read<int>(s);
-  d = mpi_types.find(id);
+  d      = mpi_types.find(id);
 }
 void read(std::istream& s, MPI_Op& o) {
   int id = read<int>(s);
-  o = mpi_ops.find(id);
+  o      = mpi_ops.find(id);
 }
 } //namespace fenix::logging::serialize

--- a/src/logging/rank_log.cpp
+++ b/src/logging/rank_log.cpp
@@ -32,7 +32,7 @@ void RankLog::serialize(std::ostream& o) const {
 
 std::string RankLog::str() const {
   return comm_log.str() + " Log " + std::to_string(rank) + " " +
-         cur_region.str();
+    cur_region.str();
 }
 
 void RankLog::reset_consistency(int target_region) {


### PR DESCRIPTION
Did a clang-format pass over the source code. Removed two orphaned functions that never get called from fenix_process_recovery.cpp. Replaced error code returns in IMR policy with FENIX_THROWs.