### PR TITLE
More flexible data member staging

### DIFF
--- a/examples/05_subset_create/subset_create.c
+++ b/examples/05_subset_create/subset_create.c
@@ -139,7 +139,9 @@ int main(int argc, char **argv) {
         subset[index] = -2;
     }
 
-    int restore_ret = Fenix_Data_member_restore(my_group, my_member, subset, kCount, FENIX_DATA_SNAPSHOT_LATEST, NULL);
+    int restore_ret = Fenix_Data_member_restore(
+        my_group, my_member, subset, kCount, FENIX_DATA_SNAPSHOT_ALL, NULL
+    );
 
     if(restore_ret != FENIX_SUCCESS){
         fprintf(stderr, "Rank %d restore failure w/ code %d\n", rank, restore_ret);

--- a/examples/06_subset_createv/subset_createv.c
+++ b/examples/06_subset_createv/subset_createv.c
@@ -130,7 +130,9 @@ int main(int argc, char **argv) {
     Fenix_Data_commit(my_group, NULL);
   } else {
     fprintf(stderr, "Doing restore on rank %d\n", rank);
-    Fenix_Data_member_restore(my_group, 777, subset, kCount, 1, NULL);
+    Fenix_Data_member_restore(
+        my_group, 777, subset, kCount, FENIX_DATA_SNAPSHOT_ALL, NULL
+    );
     fprintf(stderr, "Finished restore on rank %d\n", rank);
     recovered = 1;
 

--- a/examples/08_inline_recovery/stencil_skeleton.cpp
+++ b/examples/08_inline_recovery/stencil_skeleton.cpp
@@ -147,12 +147,12 @@ int main(int argc, char** argv) {
       try {
         data::group_create(group);
 
-        if (!data::member_created(group, state_member))
-          data::member_create(group, state_member, &state, 2, MPI_INT);
-        data::member_restore(group, state_member, &state, 2);
+        // member_define is safely idempotent, in exchange for not warning us
+        // if we are accidentally overwriting an existing member
+        data::member_define(group, state_member, &state, 2, MPI_INT);
+        mlog::define_data_member(mlogs, group, mlogs_member);
 
-        if (!data::member_created(group, mlogs_member))
-          mlog::create_data_member(mlogs, group, mlogs_member);
+        data::member_restore(group, state_member);
         data::member_restore(group, mlogs_member);
 
         mlog::sync(mlogs, state.iteration);

--- a/examples/08_inline_recovery/stencil_skeleton.cpp
+++ b/examples/08_inline_recovery/stencil_skeleton.cpp
@@ -106,6 +106,8 @@ void check_inject_failure(State& state, int app_ranks) {
 }
 
 int main(int argc, char** argv) {
+  namespace data = fenix::data;
+  namespace mlog = fenix::mlog;
   using namespace fenix::data;
   MPI_Init(&argc, &argv);
 
@@ -116,7 +118,7 @@ int main(int argc, char** argv) {
 
   // Hold on to checkpoint_iterations+1 regions at once, to be sure we can
   // replay any failed neighbor's messages
-  fenix::mlog::create(mlogs, res_world, checkpoint_iterations + 1);
+  mlog::create(mlogs, res_world, checkpoint_iterations + 1);
 
   // Grab basic MPI info
   int n_ranks, rank;
@@ -133,22 +135,27 @@ int main(int argc, char** argv) {
     state.rank      = rank;
     state.iteration = 0;
 
-    fenix::data::group_create(group);
+    data::group_create(group);
+    data::member_create(group, state_member, &state, 2, MPI_INT);
+    mlog::create_data_member(mlogs, group, mlogs_member);
 
-    fenix::data::member_create(group, state_member, &state, 2, MPI_INT);
-    fenix::data::member_stage(group, state_member);
-    fenix::mlog::stage(mlogs, group, mlogs_member);
-    fenix::data::member_store(group, SUBSET_PRESTAGED);
-    fenix::data::commit_barrier(group);
+    data::member_store(group, SUBSET_FULL);
+    data::commit_barrier(group);
   } else {
     // Recovered ranks just recover from the checkpoint instead
     while (true) {
       try {
-        fenix::data::group_create(group);
-        fenix::data::member_restore(group, state_member, &state, 2);
-        fenix::data::member_restore(group, mlogs_member, nullptr, 0);
-        fenix::mlog::lrestore(mlogs, group, mlogs_member);
-        fenix::mlog::sync(mlogs, state.iteration);
+        data::group_create(group);
+
+        if (!data::member_created(group, state_member))
+          data::member_create(group, state_member, &state, 2, MPI_INT);
+        data::member_restore(group, state_member, &state, 2);
+
+        if (!data::member_created(group, mlogs_member))
+          mlog::create_data_member(mlogs, group, mlogs_member);
+        data::member_restore(group, mlogs_member);
+
+        mlog::sync(mlogs, state.iteration);
       } catch (fenix::CommException& error) {
         continue;
       }
@@ -168,9 +175,9 @@ int main(int argc, char** argv) {
   fenix::callback_register([&](MPI_Comm repaired_comm, int mpi_err) {
     assert(fenix::error() == FENIX_SUCCESS);
 
-    fenix::data::group_create(group);
-    fenix::data::member_restore(group, state_member, NULL, 0);
-    fenix::data::member_restore(group, mlogs_member, NULL, 0);
+    data::group_create(group);
+    data::member_restore(group, state_member, NULL, 0);
+    data::member_restore(group, mlogs_member, NULL, 0);
 
     printf(
       "Rank %d continuing inline at iteration %d\n", state.rank, state.iteration
@@ -182,7 +189,7 @@ int main(int argc, char** argv) {
     check_inject_failure(state, n_ranks);
 
     // Start message log region i
-    fenix::mlog::begin_region(mlogs, i);
+    mlog::begin_region(mlogs, i);
 
     // Exchange state information, just like exchanging ghost points
     State left_state, right_state;
@@ -211,11 +218,9 @@ int main(int argc, char** argv) {
     }
 
     if (state.iteration % checkpoint_iterations == 0) {
-      fenix::data::member_stage(group, state_member);
-      fenix::mlog::stage(mlogs, group, mlogs_member);
       // With an active log and inline recovery enabled, checkpoint will
       // recover inline automatically.
-      fenix::data::checkpoint(group, SUBSET_PRESTAGED, {mlogs_member});
+      data::checkpoint(group, SUBSET_FULL, {mlogs_member});
     }
   }
 

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -59,6 +59,7 @@
 
 #include <mpi.h>
 #include <setjmp.h>
+#include <stdio.h>
 
 #include "fenix_init.h"
 
@@ -562,9 +563,13 @@ int Fenix_Finalize();
 #define FENIX_DATA_MEMBER_ATTRIBUTE_SIZE 14
 #define FENIX_DATA_SNAPSHOT_LATEST -1
 #define FENIX_DATA_SNAPSHOT_ALL -2
+#define FENIX_DATA_RESTORE_INPLACE NULL
+#define FENIX_DATA_RESTORE_FULL INT_MAX
 #define FENIX_RESIZEABLE 0
 #define FENIX_DATA_SUBSET_CREATED 2
 #define FENIX_STOREV_ALL -1
+#define FENIX_SERIALIZE -2
+#define FENIX_DESERIALIZE -3
 
 #define FENIX_DATA_POLICY_IN_MEMORY_RAID 13
 #define FENIX_DATA_POLICY_IMR FENIX_DATA_POLICY_IN_MEMORY_RAID
@@ -603,6 +608,36 @@ extern const Fenix_Data_subset FENIX_DATA_SUBSET_EMPTY;
 extern const Fenix_Data_subset FENIX_DATA_SUBSET_PRESTAGED;
 
 extern Fenix_Data_subset* FENIX_DATA_SUBSET_IGNORE;
+
+/**
+ * @brief Serializer function type for file-serializable data members.
+ *
+ * Arguments are:
+ *   FILE* fp:      memory-backed file pointer to (de)serialize into
+ *   int direction: one of FENIX_SERIALIZE or FENIX_DESERIALIZE
+ *   void* buf:     pointer to user buffer
+ *   int offset:    first index to be (de)serialized
+ *   int count:     number of entries to (de)serialize, or FENIX_RESIZEABLE
+ *   void* context: pointer to user-defined context
+ *
+ * Fenix will invoke this function to (de)serialize the data of a member.
+ * Will be invoked once per contiguous data region to be (de)serialized.
+ *
+ * When \c direction=FENIX_SERIALIZE, \c fp is write-only and \c buf is the
+ * data member's buffer (as FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER). Function should
+ * write data values [\c offset, \c offset+count) directly into \c fp. Will be
+ * invoked with \c offset=0 and \c count=FENIX_RESIZEABLE if staging
+ * FENIX_DATA_SUBSET_FULL of a member of size FENIX_RESIZEABLE, which indicates
+ * that all data should be serialized.
+ *
+ * When \c direction=FENIX_DESERIALIZE, \c fp is read-only and \c buf is the
+ * target buffer of the restore or lrestore operation being completed. Function
+ * should read data values [\c offset, \c offset+count) directly from \c fp.
+ *
+ * The user should not manipulate the file's position indicator in any way other
+ * than directly writing/reading to/from the file.
+ */
+typedef void (*Fenix_Serialize_file_fn)(FILE*, int, void*, int, int, void*);
 
 /**
  * @brief Create a Data Group
@@ -677,6 +712,14 @@ int Fenix_Data_group_created(int group_id);
  */
 int Fenix_Data_member_create(
   int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
+);
+
+/**
+ * @brief Create a data member to be (de)serialized with a file pointer
+ */
+int Fenix_Data_member_fcreate(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
+  Fenix_Serialize_file_fn serializer, void* ctx
 );
 
 /**
@@ -1188,32 +1231,16 @@ int Fenix_Mlog_activate_region(int mlog_id, int region_id);
 int Fenix_Mlog_sync(int mlog_id, int region_id);
 
 /**
- * @brief Stage an mlog's data into a Fenix data member
+ * @brief Create a data member that can be used to stage/restore this mlog
  * @qualifier local
  *
- * @param[in] mlog_id   The mlog to stage.
- * @param[in] group_id  The group to stage into.
- * @param[in] member_id The member to stage into.
- *            The member does not have to already exist.
- *            If the member already exists, it must have been created with size
- *            FENIX_RESIZEABLE and datatype MPI_BYTE
+ * @param[in] mlog_id   The mlog to link to this data member
+ * @param[in] group_id  The data group to create the member within
+ * @param[in] member_id The ID to create the member as
  * @returnstatus
- */
-int Fenix_Mlog_stage(int mlog_id, int group_id, int member_id);
-
-/**
- * @brief Restore an mlog from a Fenix data member's local snapshot
- * @qualifier local
  *
- * @param[in] mlog_id    The mlog to restore.
- * @param[in] group_id   The group to restore from.
- * @param[in] member_id  The member to restore from.
- * @param[in] time_stamp The time stamp of the snapshot to restore from.
- * @returnstatus
  */
-int Fenix_Mlog_lrestore(
-  int mlog_id, int group_id, int member_id, int time_stamp
-);
+int Fenix_Mlog_create_data_member(int mlog_id, int group_id, int member_id);
 
 /**
  * @brief Delete an mlog

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -733,6 +733,30 @@ int Fenix_Data_member_stage(
 );
 
 /**
+ * @brief As #Fenix_Data_member_stage, but takes ownership of buf to possibly
+ * avoid a copy.
+ *
+ * Fenix takes this \c buf as the new location to stage all data to. Any prior
+ * staged but uncommitted data is lost. Even if \c subset is not contiguous or
+ * begins after 0, \c buf must contain all elements from 0 to the maximum of
+ * (member's count, subset's end). Elements not belonging to the subset may be
+ * written to with subsequent calls to #Fenix_Data_member_stage.
+ *
+ * There is no guarantee that the pointer to buf will remain valid after this
+ * call. Fenix may overwrite, reallocate, or free this buffer at any time,
+ * including before returning from this function.
+ *
+ * @param group_id All ranks must provide the same group_id
+ * @param member_id All ranks must provide the same member_id
+ * @param buf The data buffer which Fenix will take ownership of
+ * @param subset Which subset of the data to stage. See #Fenix_Data_member_stage
+ * @returnstatus
+ */
+int Fenix_Data_member_stage_inplace(
+  int group_id, int member_id, void* buf, const Fenix_Data_subset subset
+);
+
+/**
  * @brief Store a particular group member into the group's resilient storage
  *  space, in uncommitted storage.
  *

--- a/include/fenix.h
+++ b/include/fenix.h
@@ -723,6 +723,30 @@ int Fenix_Data_member_fcreate(
 );
 
 /**
+ * @brief Idempotent version of #Fenix_Data_member_create
+ *
+ * If this member does not exist, behaves as #Fenix_Data_member_create.
+ * If this member does exist, updates its attributes (with the same restrictions
+ * as #Fenix_Data_member_attr_set).
+ */
+int Fenix_Data_member_define(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
+);
+
+/**
+ * @brief Idempotent version of #Fenix_Data_member_fcreate
+ *
+ * If this member does not exist, behaves as #Fenix_Data_member_fcreate.
+ * If this member does exist, updates its attributes (with the same restrictions
+ * as #Fenix_Data_member_attr_set) and its serializer function. Note that
+ * providing a nullptr for serializer will remove any existing serializer.
+ */
+int Fenix_Data_member_fdefine(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
+  Fenix_Serialize_file_fn serializer, void* ctx
+);
+
+/**
  * @brief Query if a data member exists on this rank
  * @qualifier local
  *
@@ -1238,9 +1262,20 @@ int Fenix_Mlog_sync(int mlog_id, int region_id);
  * @param[in] group_id  The data group to create the member within
  * @param[in] member_id The ID to create the member as
  * @returnstatus
- *
  */
 int Fenix_Mlog_create_data_member(int mlog_id, int group_id, int member_id);
+
+/**
+ * @brief Define a data member that can be used to stage/restore this mlog,
+ * see #Fenix_Data_member_define.
+ * @qualifier local
+ *
+ * @param[in] mlog_id   The mlog to link to this data member
+ * @param[in] group_id  The data group to create the member within
+ * @param[in] member_id The ID to create the member as
+ * @returnstatus
+ */
+int Fenix_Mlog_define_data_member(int mlog_id, int group_id, int member_id);
 
 /**
  * @brief Delete an mlog

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -212,6 +212,14 @@ int member_create(
   int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
 );
 
+//!@brief As #Fenix_Serialize_file_fn without the void* context pointer.
+using SerializeFileFunc = std::function<void(FILE*, int, void*, int, int)>;
+
+int member_create(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
+  SerializeFileFunc serializer
+);
+
 //@!brief Overload of #Fenix_Data_member_created
 bool member_created(int group_id, int member_id);
 
@@ -270,15 +278,18 @@ inline int member_istorev(
 
 //!@brief Overload of #Fenix_Data_member_restore
 int member_restore(
-  int group_id, int member_id, void* target_buffer, int max_length,
-  int time_stamp         = FENIX_DATA_SNAPSHOT_LATEST,
+  int group_id, int member_id, void* target_buffer = FENIX_DATA_RESTORE_INPLACE,
+  int max_length         = FENIX_DATA_RESTORE_FULL,
+  int time_stamp         = FENIX_DATA_SNAPSHOT_ALL,
   DataSubset& data_found = SUBSET_IGNORE
 );
 
 //!@brief Overload of #Fenix_Data_member_lrestore
 int member_lrestore(
-  int group_id, int member_id, void* target_buffer, int max_length,
-  int time_stamp, DataSubset& data_found
+  int group_id, int member_id, void* target_buffer = FENIX_DATA_RESTORE_INPLACE,
+  int max_length         = FENIX_DATA_RESTORE_FULL,
+  int time_stamp         = FENIX_DATA_SNAPSHOT_ALL,
+  DataSubset& data_found = SUBSET_IGNORE
 );
 
 //!@brief overload of #Fenix_Data_commit
@@ -341,14 +352,8 @@ int activate(int mlog_id, int region_id);
 //@brief Overload of #Fenix_Mlog_sync
 int sync(int mlog_id, int region_id = FENIX_MLOG_CONTINUE);
 
-//@brief Overload of #Fenix_Mlog_stage
-int stage(int mlog_id, int group_id, int member_id);
-
-//@brief Overload of #Fenix_Mlog_lrestore
-int lrestore(
-  int mlog_id, int group_id, int member_id,
-  int time_stamp = FENIX_DATA_SNAPSHOT_LATEST
-);
+//@brief Overload of #Fenix_Mlog_create_data_member
+int create_data_member(int mlog_id, int group_id, int member_id);
 
 //@brief Overload of #Fenix_Mlog_delete
 int mlog_delete(int mlog_id);

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -61,6 +61,8 @@
 #include <functional>
 #include <vector>
 #include <optional>
+#include <variant>
+
 #include "fenix.h"
 #include "fenix_exception.hpp"
 #include "fenix_data_subset.hpp"
@@ -214,10 +216,15 @@ int member_create(
 
 //!@brief As #Fenix_Serialize_file_fn without the void* context pointer.
 using SerializeFileFunc = std::function<void(FILE*, int, void*, int, int)>;
+//!@brief As #SerializeFileFunc using std::iostream instead of a file pointer
+using SerializeStreamFunc =
+  std::function<void(std::iostream&, int, void*, int, int)>;
+
+using SerializeFunc = std::variant<SerializeFileFunc, SerializeStreamFunc>;
 
 int member_create(
   int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
-  SerializeFileFunc serializer
+  SerializeFunc serializer
 );
 
 //@!brief Overload of #Fenix_Data_member_created

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -222,13 +222,28 @@ using SerializeStreamFunc =
 
 using SerializeFunc = std::variant<SerializeFileFunc, SerializeStreamFunc>;
 
+//!@brief Overload of #Fenix_Data_member_fcreate
 int member_create(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
+  SerializeFunc serializer
+);
+
+//!@brief Overload of #Fenix_Data_member_define
+int member_define(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
+);
+//!@brief Overload of #Fenix_Data_member_fdefine
+int member_define(
   int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
   SerializeFunc serializer
 );
 
 //@!brief Overload of #Fenix_Data_member_created
 bool member_created(int group_id, int member_id);
+
+int member_attr_set(
+  int group_id, int member_id, int attr, void* value, int* flag
+);
 
 //!@brief Overload of #Fenix_Data_member_stage
 int member_stage(
@@ -361,6 +376,9 @@ int sync(int mlog_id, int region_id = FENIX_MLOG_CONTINUE);
 
 //@brief Overload of #Fenix_Mlog_create_data_member
 int create_data_member(int mlog_id, int group_id, int member_id);
+
+//@brief Overload of #Fenix_Mlog_define_data_member
+int define_data_member(int mlog_id, int group_id, int member_id);
 
 //@brief Overload of #Fenix_Mlog_delete
 int mlog_delete(int mlog_id);

--- a/include/fenix.hpp
+++ b/include/fenix.hpp
@@ -220,6 +220,11 @@ int member_stage(
   int group_id, int member_id, const DataSubset& subset = SUBSET_FULL
 );
 
+//!@brief Overload of #Fenix_Data_member_stage_inplace
+int member_stage_inplace(
+  int group_id, int member_id, void* buf, const DataSubset& subset = SUBSET_FULL
+);
+
 //!@brief Overload of #Fenix_Data_member_store
 int member_store(
   int group_id, int member_id, const DataSubset& subset = SUBSET_FULL

--- a/include/fenix/data/mstream.hpp
+++ b/include/fenix/data/mstream.hpp
@@ -80,8 +80,9 @@ class OMmapStreamBuf : public std::streambuf {
     char* ret = nullptr;
 
 #ifdef FENIX_HAVE_MREMAP
-    ret = (char*
-    )mremap(mmap_address, claim_len, written_len(), MREMAP_MAYMOVE, nullptr);
+    ret = (char*)mremap(
+      mmap_address, claim_len, written_len(), MREMAP_MAYMOVE, nullptr
+    );
     if (ret == MAP_FAILED) fatal_print("Unexpected mremap failure");
 #else
     // We can't release the big virtual address reservation without munmaping
@@ -107,8 +108,9 @@ class OMmapStreamBuf : public std::streambuf {
 #ifdef FENIX_HAVE_MREMAP
       size_t old_claim_len = claim_len;
       grow_len(claim_len, claim_chunk_size, needed_len);
-      mmap_address = (char*
-      )mremap(mmap_address, old_claim_len, claim_len, MREMAP_MAYMOVE, nullptr);
+      mmap_address = (char*)mremap(
+        mmap_address, old_claim_len, claim_len, MREMAP_MAYMOVE, nullptr
+      );
 
       if (mmap_address == MAP_FAILED) {
         fatal_print("Out of space for serialization");
@@ -127,23 +129,6 @@ class OMmapStreamBuf : public std::streambuf {
 
     return ch;
   }
-
-  /*std::streamsize xsputn(const char* s, std::streamsize count) {
-    size_t written = 0;
-    while (written < count) {
-      size_t avail = writable_len - (pptr() - mmap_address);
-      if (avail > count - written) avail = count = written;
-
-      if (avail) {
-        memcpy(pptr(), s+written, count);
-        written += avail;
-      } else {
-        overflow(s[written]);
-        written++;
-      }
-    }
-    return count;
-  }*/
 
   pos_type seekpos(pos_type pos, std::ios_base::openmode which) {
     if (!(which & std::ios_base::out)) return 0;

--- a/include/fenix/data/mstream.hpp
+++ b/include/fenix/data/mstream.hpp
@@ -1,0 +1,256 @@
+#ifndef FENIX_DATA_MSTREAM_HPP
+#define FENIX_DATA_MSTREAM_HPP
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <streambuf>
+#include <iostream>
+#include <sys/mman.h>
+#include <errno.h>
+#include <cstring>
+
+#include "fenix_opt.hpp"
+
+namespace fenix::data {
+namespace detail {
+
+class OMmapStreamBuf : public std::streambuf {
+ public:
+  using std::streambuf::int_type;
+  using std::streambuf::off_type;
+  using std::streambuf::pos_type;
+  using Traits = std::char_traits<char>;
+
+#ifdef FENIX_HAVE_MREMAP
+  // Bytes of virtual address space claimed at a time
+  static constexpr size_t target_claim_chunk_size = 1024 * 1024 * 1024; // 1GB
+#else
+  // If we can't mremap, claim more virtual address space at once, since we
+  // can't grow
+  static constexpr size_t target_claim_chunk_size =
+    20 * 1024 * 1024 * 1024; // 20GB
+#endif
+
+  // Bytes of claimed address space made writable at a time
+  static constexpr size_t target_write_chunk_size = 1024 * 1024; // 1KB
+
+  OMmapStreamBuf() : std::streambuf() {
+    // Operate in page sized chunks, for portability
+    size_t page_size = sysconf(_SC_PAGESIZE);
+    claim_chunk_size = (target_claim_chunk_size / page_size) * page_size;
+    if (claim_chunk_size < target_claim_chunk_size * 0.75)
+      claim_chunk_size += page_size;
+    write_chunk_size = (target_write_chunk_size / page_size) * page_size;
+    if (write_chunk_size < target_write_chunk_size * 0.75)
+      write_chunk_size += page_size;
+    fenix_assert(write_chunk_size <= claim_chunk_size);
+
+    claim_len = claim_chunk_size;
+    mmap_address =
+      (char*)mmap(nullptr, claim_len, PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (mmap_address == MAP_FAILED) {
+      fatal_print("Could not mmap an address, errno %d", errno);
+    }
+
+    writable_len = write_chunk_size;
+    int err      = mprotect(mmap_address, writable_len, PROT_WRITE);
+    if (err != 0) {
+      fatal_print("Could not mprotect the allocation, errno %d", errno);
+    }
+
+    setp(mmap_address, mmap_address + writable_len);
+  }
+
+  ~OMmapStreamBuf() override {
+    if (mmap_address) munmap(mmap_address, claim_len);
+  }
+
+  size_t written_len() {
+    size_t ret = pptr() - mmap_address;
+    if (ret < written_highwater) ret = written_highwater;
+    return ret;
+  }
+
+  // buf should no longer be used after calling release()
+  // If FENIX_HAVE_MREMAP, user responsible for calling munmap on released buf.
+  // Otherwise, user responsible for calling free on released buf.
+  char* release() {
+    char* ret = nullptr;
+
+#ifdef FENIX_HAVE_MREMAP
+    ret = (char*
+    )mremap(mmap_address, claim_len, written_len(), MREMAP_MAYMOVE, nullptr);
+    if (ret == MAP_FAILED) fatal_print("Unexpected mremap failure");
+#else
+    // We can't release the big virtual address reservation without munmaping
+    char* ret = (char*)malloc(written_len());
+    memcpy(ret, mmap_address, written_len());
+    munmap(mmap_address, claim_len);
+#endif
+
+    mmap_address = nullptr;
+    claim_len = writable_len = written_highwater = 0;
+    setp(nullptr, nullptr);
+    return ret;
+  }
+
+ protected:
+  int_type overflow(int_type ch) override {
+    setp(pptr(), mmap_address + writable_len);
+    // No need to write ch if it's eof, we're simply done.
+    if (Traits::eq_int_type(ch, Traits::eof())) return Traits::not_eof(ch);
+
+    size_t needed_len = pptr() - mmap_address + 1;
+    if (claim_len < needed_len) {
+#ifdef FENIX_HAVE_MREMAP
+      size_t old_claim_len = claim_len;
+      grow_len(claim_len, claim_chunk_size, needed_len);
+      mmap_address = (char*
+      )mremap(mmap_address, old_claim_len, claim_len, MREMAP_MAYMOVE, nullptr);
+
+      if (mmap_address == MAP_FAILED) {
+        fatal_print("Out of space for serialization");
+      }
+#else
+      fatal_print("Out of space for serialization");
+#endif
+    }
+    if (writable_len < needed_len) {
+      grow_len(writable_len, write_chunk_size, needed_len);
+      mprotect(mmap_address, writable_len, PROT_WRITE);
+    }
+
+    *pptr() = Traits::to_char_type(ch);
+    setp(pptr() + 1, mmap_address + writable_len);
+
+    return ch;
+  }
+
+  /*std::streamsize xsputn(const char* s, std::streamsize count) {
+    size_t written = 0;
+    while (written < count) {
+      size_t avail = writable_len - (pptr() - mmap_address);
+      if (avail > count - written) avail = count = written;
+
+      if (avail) {
+        memcpy(pptr(), s+written, count);
+        written += avail;
+      } else {
+        overflow(s[written]);
+        written++;
+      }
+    }
+    return count;
+  }*/
+
+  pos_type seekpos(pos_type pos, std::ios_base::openmode which) {
+    if (!(which & std::ios_base::out)) return 0;
+    written_highwater = written_len();
+    setp(mmap_address + pos, mmap_address + writable_len);
+    return pos;
+  }
+
+  pos_type seekoff(
+    off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which
+  ) {
+    if (!(which & std::ios_base::out)) return 0;
+    written_highwater = written_len();
+
+    char* new_ptr = nullptr;
+    if (dir == std::ios_base::beg) new_ptr = mmap_address + off;
+    else if (dir == std::ios_base::cur) new_ptr = pptr() + off;
+    else new_ptr = mmap_address + written_len() + off;
+
+    setp(new_ptr, mmap_address + writable_len);
+    return new_ptr - mmap_address;
+  }
+
+ private:
+  void grow_len(size_t& len, size_t chunk, size_t target) {
+    if (len >= target) return;
+    len = (target / chunk) * chunk;
+    if (target % chunk != 0) len += chunk;
+    fenix_assert(len >= target);
+  }
+
+  char* mmap_address       = nullptr;
+  size_t claim_len         = 0;
+  size_t writable_len      = 0;
+  size_t written_highwater = 0;
+
+  size_t claim_chunk_size, write_chunk_size;
+};
+
+class MStreamBuf : public std::streambuf {
+ public:
+  using std::streambuf::int_type;
+  using std::streambuf::off_type;
+  using std::streambuf::pos_type;
+  using Traits = std::char_traits<char>;
+
+  MStreamBuf(char* b, size_t l) : std::streambuf() {
+    buf = b;
+    len = l;
+    setp(buf, buf + len);
+    setg(buf, buf, buf + len);
+  }
+
+  ~MStreamBuf() override = default;
+
+ protected:
+  int_type overflow(int_type ch) override {
+    // This class is not designed to dynamically allocate, any accesses outside
+    // of the pre-sized region are erroneous.
+    fatal_print("MStreamBuf overflow");
+  }
+
+  pos_type seekpos(pos_type pos, std::ios_base::openmode which) {
+    if (which & std::ios_base::out) setp(buf + pos, buf + len);
+    if (which & std::ios_base::in) setg(buf, buf + pos, buf + len);
+    return pos;
+  }
+
+  pos_type seekoff(
+    off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which
+  ) {
+    if (dir == std::ios_base::cur) {
+      if (which & std::ios_base::out) setp(pptr() + off, buf + len);
+      if (which == std::ios_base::out) return pptr() - buf;
+      setg(buf, gptr() + off, buf + len);
+      return gptr() - buf;
+    } else {
+      size_t pos = dir == std::ios_base::beg ? off : len + off;
+      return seekpos(pos, which);
+    }
+  }
+
+ private:
+  char* buf  = nullptr;
+  size_t len = 0;
+};
+
+} //namespace detail
+
+class MStream : public std::iostream {
+ public:
+  MStream() : std::iostream(nullptr) {
+    buf = std::make_unique<detail::OMmapStreamBuf>();
+    rdbuf(buf.get());
+  }
+  MStream(char* b, size_t l) : std::iostream(nullptr) {
+    buf = std::make_unique<detail::MStreamBuf>(b, l);
+    rdbuf(buf.get());
+  }
+  ~MStream() = default;
+
+  std::streambuf* get_buf() { return buf.get(); }
+
+ private:
+  std::unique_ptr<std::streambuf> buf;
+};
+
+} //namespace fenix::data
+
+#endif

--- a/include/fenix_data_buffer.hpp
+++ b/include/fenix_data_buffer.hpp
@@ -64,46 +64,75 @@
 #include "fenix/tasks/forward.hpp"
 
 namespace fenix {
-namespace detail {
 
-template <typename T>
-struct UninitializedCharAllocator : public std::allocator<T> {
-  UninitializedCharAllocator() noexcept {};
-  template <typename U>
-  UninitializedCharAllocator(const U& other) noexcept {};
-
-  using value_type = T;
-  void construct(char*) {};
-
-  template <typename U>
-  struct rebind {
-    using other = UninitializedCharAllocator<U>;
-  };
-};
-
-using BufferVec = std::vector<char, UninitializedCharAllocator<char>>;
-
-}
-
-class DataBuffer : public detail::BufferVec {
+class DataBuffer {
  public:
-  using BufferVec = detail::BufferVec;
-  using MPITask   = tasks::mpi::MPITask;
+  using MPITask = tasks::mpi::MPITask;
 
-  //Set to new size, possibly discarding old data
+  DataBuffer() = default;
+  explicit DataBuffer(size_t init_size) { resize(init_size); }
+
+  ~DataBuffer() { free_buf(); }
+
+  DataBuffer(const DataBuffer& o) = delete;
+
+  DataBuffer(DataBuffer&& o) { *this = std::move(o); }
+  DataBuffer& operator=(DataBuffer&& o) {
+    if (&o == this) return *this;
+    free_buf();
+    *this = o;
+    o.release_buf();
+    return *this;
+  }
+
+  // Simple resize without overallocating.
+  // No ammortized growth cost, but we don't need it for our usage
+  void resize(size_t new_size);
+  void shrink_to_fit();
+  void clear() { resize(0); }
+
+  // Set to new size, discarding old data if reallocation is needed
   void reset(size_t new_size = 0) {
-    //Clear first, to be sure any re-allocations don't actually move data
-    clear();
+    resize(0);
     resize(new_size);
   }
 
+  void reserve(size_t new_size) {
+    size_t old_size = user_size;
+    resize(new_size);
+    resize(old_size);
+  }
+
+  char* data() { return buf; }
+  const char* data() const { return buf; }
+  size_t size() const { return user_size; }
+
   MPITask send(int dst, int tag, MPI_Comm comm);
 
-  //Recv n bytes
+  // Recv n bytes
   MPITask recv(int n, int src, int tag, MPI_Comm comm);
 
-  //Recv an unknown amount of data and resize to fit
+  // Recv an unknown amount of data and resize to fit
   MPITask recv_unknown(int src, int tag, MPI_Comm comm);
+
+ private:
+  char* buf        = nullptr;
+  size_t user_size = 0, alloc_size = 0;
+
+  DataBuffer& operator=(const DataBuffer& o) {
+    this->buf        = o.buf;
+    this->user_size  = o.user_size;
+    this->alloc_size = o.alloc_size;
+    return *this;
+  }
+  void free_buf() {
+    free(buf);
+    release_buf();
+  }
+  void release_buf() {
+    buf       = nullptr;
+    user_size = alloc_size = 0;
+  }
 };
 
 } // namespace fenix

--- a/include/fenix_data_buffer.hpp
+++ b/include/fenix_data_buffer.hpp
@@ -87,8 +87,17 @@ class DataBuffer {
 
   void take_ownership(char* new_buf, size_t new_size) {
     free_buf();
-    buf       = new_buf;
-    user_size = alloc_size = new_size;
+    buf        = new_buf;
+    user_size  = new_size;
+    alloc_size = new_size;
+  }
+
+  void take_ownership_mmapped(char* new_buf, size_t new_size) {
+    free_buf();
+    buf         = new_buf;
+    user_size   = new_size;
+    alloc_size  = new_size;
+    mmap_buffer = true;
   }
 
   // Simple resize without overallocating.
@@ -122,23 +131,26 @@ class DataBuffer {
   MPITask recv_unknown(int src, int tag, MPI_Comm comm);
 
  private:
-  char* buf        = nullptr;
-  size_t user_size = 0, alloc_size = 0;
+  char* buf         = nullptr;
+  size_t user_size  = 0;
+  size_t alloc_size = 0;
+  bool mmap_buffer  = false;
 
   DataBuffer& operator=(const DataBuffer& o) {
-    this->buf        = o.buf;
-    this->user_size  = o.user_size;
-    this->alloc_size = o.alloc_size;
+    this->buf         = o.buf;
+    this->user_size   = o.user_size;
+    this->alloc_size  = o.alloc_size;
+    this->mmap_buffer = o.mmap_buffer;
     return *this;
   }
-  void free_buf() {
-    free(buf);
-    release_buf();
-  }
+  void free_buf();
   void release_buf() {
-    buf       = nullptr;
-    user_size = alloc_size = 0;
+    buf         = nullptr;
+    user_size   = 0;
+    alloc_size  = 0;
+    mmap_buffer = false;
   }
+  void realloc_buf(size_t new_size);
 };
 
 } // namespace fenix

--- a/include/fenix_data_buffer.hpp
+++ b/include/fenix_data_buffer.hpp
@@ -85,6 +85,12 @@ class DataBuffer {
     return *this;
   }
 
+  void take_ownership(char* new_buf, size_t new_size) {
+    free_buf();
+    buf       = new_buf;
+    user_size = alloc_size = new_size;
+  }
+
   // Simple resize without overallocating.
   // No ammortized growth cost, but we don't need it for our usage
   void resize(size_t new_size);

--- a/include/fenix_data_group.hpp
+++ b/include/fenix_data_group.hpp
@@ -94,6 +94,10 @@ struct fenix_group_t {
     int id, std::source_location loc = std::source_location::current()
   );
   int member_create(int id, void* data, int count, MPI_Datatype datatype);
+  int member_create(
+    int id, void* data, int count, MPI_Datatype datatype,
+    SerializeFileFunc& serializer
+  );
   int member_create(int id, void* data, int count, int datatype_size);
   int member_delete(int memberid);
 

--- a/include/fenix_data_group.hpp
+++ b/include/fenix_data_group.hpp
@@ -95,8 +95,7 @@ struct fenix_group_t {
   );
   int member_create(int id, void* data, int count, MPI_Datatype datatype);
   int member_create(
-    int id, void* data, int count, MPI_Datatype datatype,
-    SerializeFileFunc& serializer
+    int id, void* data, int count, MPI_Datatype datatype, SerializeFunc& s
   );
   int member_create(int id, void* data, int count, int datatype_size);
   int member_delete(int memberid);

--- a/include/fenix_data_group.hpp
+++ b/include/fenix_data_group.hpp
@@ -102,8 +102,11 @@ struct fenix_group_t {
   virtual int member_delete(fenix_member_entry_t* member)             = 0;
   virtual int get_redundant_policy(int* name, void* value, int* flag) = 0;
   virtual void member_stage(int memberid, const DataSubset& subset)   = 0;
-  virtual int member_store(int memberid, const DataSubset& subset)    = 0;
-  virtual int member_storev(int memberid, const DataSubset& subset)   = 0;
+  virtual void member_stage_inplace(
+    int memberid, void* buf, const DataSubset& subset
+  )                                                                 = 0;
+  virtual int member_store(int memberid, const DataSubset& subset)  = 0;
+  virtual int member_storev(int memberid, const DataSubset& subset) = 0;
   virtual int member_istore(
     int memberid, const DataSubset& subset, Fenix_Request* req
   ) = 0;

--- a/include/fenix_data_member.hpp
+++ b/include/fenix_data_member.hpp
@@ -70,6 +70,9 @@ struct fenix_member_entry_packet_t {
 struct fenix_member_entry_t {
   fenix_member_entry_t() = default;
   fenix_member_entry_t(int id, void* data, int count, MPI_Datatype datatype);
+  fenix_member_entry_t(
+    int id, void* data, int count, MPI_Datatype datatype, SerializeFileFunc& s
+  );
   fenix_member_entry_t(int id, void* data, int count, int datatype_size);
 
   fenix_member_entry_packet_t to_packet();
@@ -78,6 +81,8 @@ struct fenix_member_entry_t {
   char* user_data = nullptr;
   int current_count;
   int datatype_size;
+
+  SerializeFileFunc serializer = nullptr;
 };
 
 } // namespace fenix::data

--- a/include/fenix_data_member.hpp
+++ b/include/fenix_data_member.hpp
@@ -70,10 +70,10 @@ struct fenix_member_entry_packet_t {
 struct fenix_member_entry_t {
   fenix_member_entry_t() = default;
   fenix_member_entry_t(int id, void* data, int count, MPI_Datatype datatype);
-  fenix_member_entry_t(
-    int id, void* data, int count, MPI_Datatype datatype, SerializeFileFunc& s
-  );
   fenix_member_entry_t(int id, void* data, int count, int datatype_size);
+  fenix_member_entry_t(
+    int id, void* data, int count, MPI_Datatype datatype, SerializeFunc& s
+  );
 
   fenix_member_entry_packet_t to_packet();
 
@@ -82,7 +82,7 @@ struct fenix_member_entry_t {
   int current_count;
   int datatype_size;
 
-  SerializeFileFunc serializer = nullptr;
+  std::optional<SerializeFunc> serializer;
 };
 
 } // namespace fenix::data

--- a/include/fenix_data_policy_in_memory_raid.hpp
+++ b/include/fenix_data_policy_in_memory_raid.hpp
@@ -115,6 +115,7 @@ struct Member {
   bool snapshot_delete(int timestamp);
 
   void stage(const DataSubset& subset);
+  void stage_inplace(void* buf, const DataSubset& subset);
 
   //Member::istore(v) copies local data and region.
   tasks::Task<int> istore(const DataSubset& subset);
@@ -202,6 +203,9 @@ struct Group : public fenix_group_t {
   int get_redundant_policy(int* name, void* value, int* flag) override;
 
   void member_stage(int member_id, const DataSubset& subset) override;
+  void member_stage_inplace(
+    int member_id, void* buf, const DataSubset& subset
+  ) override;
 
   int member_store(int member_id, const DataSubset& subset) override;
   int member_storev(int member_id, const DataSubset& subset) override;

--- a/include/fenix_data_policy_in_memory_raid.hpp
+++ b/include/fenix_data_policy_in_memory_raid.hpp
@@ -148,6 +148,10 @@ struct Member {
 
   DataBuffer& send_buf;
   DataBuffer& recv_buf;
+
+ private:
+  void stage_resizeable(const DataSubset& subset, SerializeFileFunc& f);
+  void stage_resizeable(const DataSubset& subset, SerializeStreamFunc& f);
 };
 
 struct BuddyMember : public Member {

--- a/include/fenix_data_subset.hpp
+++ b/include/fenix_data_subset.hpp
@@ -140,6 +140,10 @@ struct DataRegion {
 struct DataSubset {
   static constexpr size_t MAX = detail::DataRegion::MAX;
 
+  // Redeclaring here to avoid cyclic dependency
+  using SerializeFileFunc = std::function<void(FILE*, int, void*, int, int)>;
+  static inline SerializeFileFunc DEFAULT_SERIALIZER = nullptr;
+
   enum SubsetType {
     BasicSubset,
     PrestagedSubset,
@@ -207,19 +211,25 @@ struct DataSubset {
   //If src_len == 0, will assume src is a large as needed
   //Will resize dst if too small
   void copy_data(
-    const size_t elm_size, const size_t src_len, const char* src,
-    DataBuffer& dst
+    const size_t elm_size, const size_t src_len, char* src, DataBuffer& dst,
+    SerializeFileFunc& serializer = DEFAULT_SERIALIZER
   ) const;
   //If dst_len == 0, will assume dst is as large as needed
   void copy_data(
-    const size_t elm_size, const DataBuffer& src, const size_t dst_len,
-    char* dst
+    const size_t elm_size, DataBuffer& src, const size_t dst_len, char* dst,
+    SerializeFileFunc& serializer = DEFAULT_SERIALIZER
   ) const;
 
   //Whether this subset includes the element at index idx
   bool includes(size_t idx) const;
   //Whether this subset includes the entire range [0, end] without gaps
   bool includes_all(size_t end) const;
+
+  //Return a DataSubset consisting of bounded_regions(max_index)
+  DataSubset bounded(size_t max_index) const;
+
+  //Bound this subset in place
+  DataSubset& bound(size_t max_index);
 
   //Return equivalent of regions & [0, max_index]
   std::set<detail::DataRegion> bounded_regions(size_t max_index) const;

--- a/include/fenix_data_subset.hpp
+++ b/include/fenix_data_subset.hpp
@@ -65,6 +65,7 @@
 #include <optional>
 #include <limits>
 #include <string>
+#include <variant>
 
 namespace fenix {
 
@@ -142,7 +143,10 @@ struct DataSubset {
 
   // Redeclaring here to avoid cyclic dependency
   using SerializeFileFunc = std::function<void(FILE*, int, void*, int, int)>;
-  static inline SerializeFileFunc DEFAULT_SERIALIZER = nullptr;
+  using SerializeStreamFunc =
+    std::function<void(std::iostream&, int, void*, int, int)>;
+  using SerializeFunc = std::variant<SerializeFileFunc, SerializeStreamFunc>;
+  using Serializer    = std::optional<SerializeFunc>;
 
   enum SubsetType {
     BasicSubset,
@@ -208,16 +212,22 @@ struct DataSubset {
     size_t elm_size, const DataBuffer& src, DataBuffer& dst
   ) const;
 
-  //If src_len == 0, will assume src is a large as needed
-  //Will resize dst if too small
+  //Serialize data into dst buffer
+  //If src_len == 0, will assume src is a large as needed. May resize dst.
   void copy_data(
-    const size_t elm_size, const size_t src_len, char* src, DataBuffer& dst,
-    SerializeFileFunc& serializer = DEFAULT_SERIALIZER
+    const size_t elm_size, const size_t src_len, char* src, DataBuffer& dst
   ) const;
+  void copy_data(
+    const size_t, const size_t, char*, DataBuffer&, Serializer&
+  ) const;
+
+  //Deserialize data from src buffer
   //If dst_len == 0, will assume dst is as large as needed
   void copy_data(
-    const size_t elm_size, DataBuffer& src, const size_t dst_len, char* dst,
-    SerializeFileFunc& serializer = DEFAULT_SERIALIZER
+    const size_t elm_size, DataBuffer& src, const size_t dst_len, char* dst
+  ) const;
+  void copy_data(
+    const size_t, DataBuffer&, const size_t, char*, Serializer&
   ) const;
 
   //Whether this subset includes the element at index idx

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@
 #  directory.
 #
 
+include(CheckSymbolExists)
+
 set(Fenix_SOURCES
     fenix.cpp
     fenix_opt.cpp
@@ -34,6 +36,21 @@ FILE(GLOB_RECURSE Fenix_HEADERS ${Fenix_INCLUDE}/*.h ${Fenix_INCLUDE}/*.hpp)
 
 configure_file(${Fenix_INCLUDE}/fenix-config.h.in fenix-config.h @ONLY)
 
+# Set preprocessor definitions to use
+set(Fenix_DEFINE "")
+if (FENIX_C_CATCH_RUNTIME_EXCEPTIONS)
+    set(Fenix_DEFINE "${Fenix_DEFINE} FENIX_C_CATCH_RUNTIME_EXCEPTIONS")
+endif()
+if (FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS)
+    set(Fenix_DEFINE "${Fenix_DEFINE} FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS")
+endif()
+
+list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
+check_symbol_exists(mremap "sys/mman.h" FENIX_HAVE_MREMAP)
+if (FENIX_HAVE_MREMAP)
+    set(Fenix_DEFINE "${Fenix_DEFINE} FENIX_HAVE_MREMAP")
+endif()
+
 foreach(FENIX_LIB fenix mlog)
     target_sources(${FENIX_LIB} PUBLIC FILE_SET HEADERS
         BASE_DIRS ${Fenix_INCLUDE} ${CMAKE_CURRENT_BINARY_DIR}
@@ -41,12 +58,8 @@ foreach(FENIX_LIB fenix mlog)
 
     target_compile_features(${FENIX_LIB} PUBLIC cxx_std_20)
     target_link_libraries(${FENIX_LIB} PUBLIC MPI::MPI_CXX)
-
-    if(FENIX_C_CATCH_RUNTIME_EXCEPTIONS)
-        target_compile_definitions(${FENIX_LIB} PUBLIC FENIX_C_CATCH_RUNTIME_EXCEPTIONS)
-    endif()
-    if(FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS)
-        target_compile_definitions(${FENIX_LIB} PUBLIC FENIX_CPP_CATCH_RUNTIME_EXCEPTIONS)
+    if (NOT "${Fenix_DEFINE}" STREQUAL "")
+        target_compile_definitions(${FENIX_LIB} PUBLIC ${Fenix_DEFINE})
     endif()
 endforeach()
 

--- a/src/fenix.cpp
+++ b/src/fenix.cpp
@@ -300,6 +300,53 @@ int Fenix_Data_member_create(
   FENIX_C_API_END
 }
 
+int Fenix_Data_member_fcreate(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
+  Fenix_Serialize_file_fn serializer, void* ctx
+) {
+  FENIX_C_API_BEGIN
+  return member_create(
+    group_id, member_id, buffer, count, datatype,
+    [serializer, ctx](FILE* fp, int d, void* b, int o, int c) {
+      return serializer(fp, d, b, o, c, ctx);
+    }
+  );
+  FENIX_C_API_END
+}
+
+int Fenix_Data_member_define(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype
+) {
+  FENIX_C_API_BEGIN
+  return member_define(group_id, member_id, buffer, count, datatype);
+  FENIX_C_API_END
+}
+
+int Fenix_Data_member_fdefine(
+  int group_id, int member_id, void* buffer, int count, MPI_Datatype datatype,
+  Fenix_Serialize_file_fn serializer, void* ctx
+) {
+  FENIX_C_API_BEGIN
+  int ret = member_define(group_id, member_id, buffer, count, datatype);
+  if (ret == FENIX_SUCCESS) {
+    find_group(group_id)->find_member(member_id)->serializer.emplace(
+      [serializer, ctx](FILE* fp, int d, void* b, int o, int c) {
+        return serializer(fp, d, b, o, c, ctx);
+      }
+    );
+  }
+  return ret;
+  FENIX_C_API_END
+}
+
+int Fenix_Data_member_attr_set(
+  int groupid, int memberid, int name, void* value, int* flag
+) {
+  FENIX_C_API_BEGIN
+  return member_attr_set(groupid, memberid, name, value, flag);
+  FENIX_C_API_END
+}
+
 int Fenix_Data_member_created(int group_id, int member_id) {
   FENIX_C_API_BEGIN
   return member_created(group_id, member_id);
@@ -495,6 +542,18 @@ int Fenix_Mlog_activate_region(int mlog_id, int region_id) {
 int Fenix_Mlog_sync(int mlog_id, int region_id) {
   FENIX_C_API_BEGIN
   return mlog::sync(mlog_id, region_id);
+  FENIX_C_API_END
+}
+
+int Fenix_Mlog_create_data_member(int mlog_id, int group_id, int member_id) {
+  FENIX_C_API_BEGIN
+  return mlog::create_data_member(mlog_id, group_id, member_id);
+  FENIX_C_API_END
+}
+
+int Fenix_Mlog_define_data_member(int mlog_id, int group_id, int member_id) {
+  FENIX_C_API_BEGIN
+  return mlog::define_data_member(mlog_id, group_id, member_id);
   FENIX_C_API_END
 }
 

--- a/src/fenix.cpp
+++ b/src/fenix.cpp
@@ -498,20 +498,6 @@ int Fenix_Mlog_sync(int mlog_id, int region_id) {
   FENIX_C_API_END
 }
 
-int Fenix_Mlog_stage(int mlog_id, int group_id, int member_id) {
-  FENIX_C_API_BEGIN
-  return mlog::stage(mlog_id, group_id, member_id);
-  FENIX_C_API_END
-}
-
-int Fenix_Mlog_lrestore(
-  int mlog_id, int group_id, int member_id, int time_stamp
-) {
-  FENIX_C_API_BEGIN
-  return mlog::lrestore(mlog_id, group_id, member_id, time_stamp);
-  FENIX_C_API_END
-}
-
 int Fenix_Mlog_delete(int mlog_id) {
   FENIX_C_API_BEGIN
   return mlog::mlog_delete(mlog_id);

--- a/src/fenix_data_buffer.cpp
+++ b/src/fenix_data_buffer.cpp
@@ -55,11 +55,46 @@
 */
 
 #include "fenix_data_buffer.hpp"
+#include "fenix_opt.hpp"
 #include "fenix/tasks/mpi.hpp"
+
+#include <cstdlib>
 
 using namespace fenix::tasks::mpi;
 
 namespace fenix {
+
+void DataBuffer::resize(size_t new_size) {
+  if (new_size <= alloc_size) {
+    user_size = new_size;
+  } else {
+    shrink_to_fit();
+
+    char* new_buf = (char*)realloc(buf, new_size);
+    if (new_buf == nullptr) {
+      error_print(
+        "unable to resize buffer to %llu bytes", (unsigned long long)new_size
+      );
+      free_buf();
+      abort();
+    } else {
+      buf       = new_buf;
+      user_size = alloc_size = new_size;
+    }
+  }
+}
+
+void DataBuffer::shrink_to_fit() {
+  if (user_size == 0) {
+    free_buf();
+  } else if (user_size < alloc_size) {
+    char* new_buf = (char*)realloc(buf, user_size);
+    fenix_assert(new_buf != nullptr);
+    buf        = new_buf;
+    alloc_size = user_size;
+  }
+}
+
 MPITask DataBuffer::send(int dst, int tag, MPI_Comm comm) {
   return tasks::mpi::send(data(), size(), MPI_BYTE, dst, tag, comm);
 }

--- a/src/fenix_data_buffer.cpp
+++ b/src/fenix_data_buffer.cpp
@@ -58,6 +58,8 @@
 #include "fenix_opt.hpp"
 #include "fenix/tasks/mpi.hpp"
 
+#include <sys/mman.h>
+#include <cstring>
 #include <cstdlib>
 
 using namespace fenix::tasks::mpi;
@@ -65,34 +67,51 @@ using namespace fenix::tasks::mpi;
 namespace fenix {
 
 void DataBuffer::resize(size_t new_size) {
-  if (new_size <= alloc_size) {
-    user_size = new_size;
-  } else {
-    shrink_to_fit();
-
-    char* new_buf = (char*)realloc(buf, new_size);
-    if (new_buf == nullptr) {
-      error_print(
-        "unable to resize buffer to %llu bytes", (unsigned long long)new_size
-      );
-      free_buf();
-      abort();
-    } else {
-      buf       = new_buf;
-      user_size = alloc_size = new_size;
-    }
-  }
+  if (new_size >= alloc_size) realloc_buf(new_size);
+  user_size = new_size;
 }
 
 void DataBuffer::shrink_to_fit() {
-  if (user_size == 0) {
-    free_buf();
-  } else if (user_size < alloc_size) {
-    char* new_buf = (char*)realloc(buf, user_size);
+  if (user_size < alloc_size) realloc_buf(user_size);
+}
+
+void DataBuffer::realloc_buf(size_t new_size) {
+  if (new_size == 0) return free_buf();
+
+  char* new_buf;
+  if (mmap_buffer) {
+    new_buf = (char*)malloc(new_size);
     fenix_assert(new_buf != nullptr);
-    buf        = new_buf;
-    alloc_size = user_size;
+    size_t copy_size = user_size < new_size ? user_size : new_size;
+    memcpy(new_buf, buf, copy_size);
+    free_buf();
+  } else if (user_size == 0) {
+    free_buf();
+    new_buf = (char*)malloc(new_size);
+  } else {
+    new_buf = (char*)realloc(buf, new_size);
   }
+
+  if (new_buf == nullptr) {
+    error_print(
+      "unable to resize buffer to %llu bytes", (unsigned long long)new_size
+    );
+    free_buf();
+    abort();
+  } else {
+    buf        = new_buf;
+    alloc_size = new_size;
+    if (user_size > alloc_size) user_size = alloc_size;
+  }
+}
+
+void DataBuffer::free_buf() {
+  if (mmap_buffer) {
+    munmap(buf, alloc_size);
+  } else if (buf) {
+    free(buf);
+  }
+  release_buf();
 }
 
 MPITask DataBuffer::send(int dst, int tag, MPI_Comm comm) {

--- a/src/fenix_data_group.cpp
+++ b/src/fenix_data_group.cpp
@@ -121,7 +121,7 @@ int fenix_group_t::member_create(
 }
 
 int fenix_group_t::member_create(
-  int id, void* data, int count, MPI_Datatype datatype, SerializeFileFunc& s
+  int id, void* data, int count, MPI_Datatype datatype, SerializeFunc& s
 ) {
   auto [iter, emplaced] = members.try_emplace(id, id, data, count, datatype, s);
   if (!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);

--- a/src/fenix_data_group.cpp
+++ b/src/fenix_data_group.cpp
@@ -121,6 +121,15 @@ int fenix_group_t::member_create(
 }
 
 int fenix_group_t::member_create(
+  int id, void* data, int count, MPI_Datatype datatype, SerializeFileFunc& s
+) {
+  auto [iter, emplaced] = members.try_emplace(id, id, data, count, datatype, s);
+  if (!emplaced) FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
+  member_order.push_back(id);
+  return this->member_create(&iter->second);
+}
+
+int fenix_group_t::member_create(
   int id, void* data, int count, int datatype_size
 ) {
   auto [iter, emplaced] =

--- a/src/fenix_data_member.cpp
+++ b/src/fenix_data_member.cpp
@@ -70,13 +70,16 @@ fenix_member_entry_packet_t fenix_member_entry_t::to_packet() {
 
 fenix_member_entry_t::fenix_member_entry_t(
   int id, void* data, int count, MPI_Datatype datatype
-)
-  : fenix_member_entry_t(id, data, count, __fenix_get_size(datatype)) {};
+) : fenix_member_entry_t(id, data, count, __fenix_get_size(datatype)) {};
+
+fenix_member_entry_t::fenix_member_entry_t(
+  int id, void* data, int count, MPI_Datatype datatype, SerializeFileFunc& s
+) : memberid(id), user_data((char*)data), current_count(count),
+    datatype_size(__fenix_get_size(datatype)), serializer(s) {};
 
 fenix_member_entry_t::fenix_member_entry_t(
   int id, void* data, int count, int dsize
-)
-  : memberid(id), user_data((char*)data), current_count(count),
+) : memberid(id), user_data((char*)data), current_count(count),
     datatype_size(dsize) {};
 
 } //namespace fenix::data

--- a/src/fenix_data_member.cpp
+++ b/src/fenix_data_member.cpp
@@ -73,7 +73,7 @@ fenix_member_entry_t::fenix_member_entry_t(
 ) : fenix_member_entry_t(id, data, count, __fenix_get_size(datatype)) {};
 
 fenix_member_entry_t::fenix_member_entry_t(
-  int id, void* data, int count, MPI_Datatype datatype, SerializeFileFunc& s
+  int id, void* data, int count, MPI_Datatype datatype, SerializeFunc& s
 ) : memberid(id), user_data((char*)data), current_count(count),
     datatype_size(__fenix_get_size(datatype)), serializer(s) {};
 

--- a/src/fenix_data_policy_in_memory_raid.cpp
+++ b/src/fenix_data_policy_in_memory_raid.cpp
@@ -78,6 +78,7 @@
 #include "fenix_data_member.hpp"
 #include "fenix_data_policy_in_memory_raid.hpp"
 #include "fenix/tasks/mpi.hpp"
+#include "fenix/data/mstream.hpp"
 
 #define __FENIX_IMR_DEFAULT_MENTRY_NUM 10
 #define __FENIX_IMR_NO_MEMBERS 16000
@@ -204,26 +205,17 @@ void Member::stage(const DataSubset& subset) {
   Entry& e = entries.back();
   if (e.elm_max_count == 0 && subset == SUBSET_FULL) {
     // Staging when we don't know the size of the data
-    if (!mentry.serializer) FENIX_THROW(
-      "Cannot stage SUBSET_FULL to non-serializable resizeable member"
-    );
-    
-    // Serializing an unknown sized member takes special care. Use a memstream,
-    // which serves as a dynamically-sized memory-backed file pointer.
-    char* buf   = nullptr;
-    size_t size = 0;
-    FILE* fp    = open_memstream(&buf, &size);
-    fenix_assert(fp != nullptr);
-
-    // Serialize into the memstream before closing it
-    mentry.serializer(
-      fp, FENIX_SERIALIZE, mentry.user_data, 0, FENIX_RESIZEABLE
-    );
-    fclose(fp);
-
-    // Stage the final data
-    fenix_assert(size % e.elm_size == 0);
-    stage_inplace(buf, DataSubset((size / e.elm_size) - 1));
+    if (!mentry.serializer) {
+      FENIX_THROW(
+        "Cannot stage SUBSET_FULL to non-serializable resizeable member"
+      );
+    } else if (mentry.serializer->index() == 0) {
+      stage_resizeable(subset, std::get<0>(*mentry.serializer));
+    } else if (mentry.serializer->index() == 1) {
+      stage_resizeable(subset, std::get<1>(*mentry.serializer));
+    } else {
+      FENIX_THROW("Unsupported serializer for unknown serialization size");
+    }
   } else {
     // Normal case staging
     e.add_and_fit(subset);
@@ -231,6 +223,44 @@ void Member::stage(const DataSubset& subset) {
       e.elm_size, e.elm_max_count, mentry.user_data, e.buf, mentry.serializer
     );
   }
+}
+
+void Member::stage_resizeable(const DataSubset& subset, SerializeFileFunc& f) {
+  // A memstream which serves as a dynamically-sized memory-backed file pointer.
+  char* buf   = nullptr;
+  size_t size = 0;
+  FILE* fp    = open_memstream(&buf, &size);
+  fenix_assert(fp != nullptr);
+
+  // Serialize into the memstream before closing it
+  f(fp, FENIX_SERIALIZE, mentry.user_data, 0, FENIX_RESIZEABLE);
+  fclose(fp);
+
+  // Stage the final data
+  Entry& e = entries.back();
+  fenix_assert(size % e.elm_size == 0);
+  stage_inplace(buf, DataSubset((size / e.elm_size) - 1));
+}
+
+void Member::stage_resizeable(
+  const DataSubset& subset, SerializeStreamFunc& f
+) {
+  MStream strm;
+  f(strm, FENIX_SERIALIZE, mentry.user_data, 0, FENIX_RESIZEABLE);
+  auto sbuf = dynamic_cast<detail::OMmapStreamBuf*>(strm.get_buf());
+
+  size_t size = sbuf->written_len();
+  char* buf   = sbuf->release();
+
+  Entry& e = entries.back();
+  fenix_assert(size % e.elm_size == 0);
+
+#ifdef FENIX_HAVE_MREMAP
+  e.buf.take_ownership_mmapped(buf, size);
+#else
+  e.buf.take_ownership(buf, size);
+#endif
+  e.region = DataSubset((size / e.elm_size) - 1);
 }
 
 void Member::stage_inplace(void* buf, const DataSubset& subset) {
@@ -245,7 +275,7 @@ void Member::stage_inplace(void* buf, const DataSubset& subset) {
   else if (e.elm_max_count && count > e.elm_max_count) count = e.elm_max_count;
 
   e.buf.take_ownership((char*)buf, count * e.elm_size);
-  e.region = DataSubset({0, count - 1});
+  e.region = subset.bounded(count - 1);
 }
 
 tasks::Task<int> Member::istorev(const DataSubset& subset) {

--- a/src/fenix_data_policy_in_memory_raid.cpp
+++ b/src/fenix_data_policy_in_memory_raid.cpp
@@ -189,12 +189,29 @@ bool Member::snapshot_delete(int timestamp) {
 }
 
 void Member::stage(const DataSubset& subset) {
-  if (subset == SUBSET_PRESTAGED)
-    FENIX_THROW("Cannot stage FENIX_DATA_SUBSET_PRESTAGED");
+  if (subset == SUBSET_PRESTAGED) FENIX_THROW("Cannot stage SUBSET_PRESTAGED");
 
   Entry& e = entries.back();
+  if (e.elm_max_count == 0 && subset == SUBSET_FULL)
+    FENIX_THROW("Cannot stage SUBSET_FULL to FENIX_RESIZEABLE member");
+
   e.add_and_fit(subset);
   subset.copy_data(e.elm_size, e.elm_max_count, mentry.user_data, e.buf);
+}
+
+void Member::stage_inplace(void* buf, const DataSubset& subset) {
+  if (subset == SUBSET_PRESTAGED) FENIX_THROW("Cannot stage SUBSET_PRESTAGED");
+
+  Entry& e = entries.back();
+  if (e.elm_max_count == 0 && subset == SUBSET_FULL)
+    FENIX_THROW("Cannot stage SUBSET_FULL to FENIX_RESIZEABLE member");
+
+  int count = subset.max_count();
+  if (subset == SUBSET_FULL) count = e.elm_max_count;
+  else if (count > e.elm_max_count) count = e.elm_max_count;
+
+  e.buf.take_ownership(buf, count * e.elm_size);
+  e.region = subset;
 }
 
 tasks::Task<int> Member::istorev(const DataSubset& subset) {
@@ -740,6 +757,14 @@ void Group::member_stage(int member_id, const DataSubset& subset) {
   auto iter = member_data.find(member_id);
   if (iter == member_data.end()) FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
   iter->second->stage(subset);
+}
+
+void Group::member_stage_inplace(
+  int member_id, void* buf, const DataSubset& subset
+) {
+  auto iter = member_data.find(member_id);
+  if (iter == member_data.end()) FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+  iter->second->stage_inplace(buf, subset);
 }
 
 int Group::member_store(int member_id, const DataSubset& subset) {

--- a/src/fenix_data_policy_in_memory_raid.cpp
+++ b/src/fenix_data_policy_in_memory_raid.cpp
@@ -115,22 +115,32 @@ void Entry::partner_resize(int size) { partner_buf.resize(size); }
 int Entry::partner_size() { return partner_buf.size(); }
 
 void Entry::add_and_fit(const DataSubset& subset) {
+  fenix_assert(subset != SUBSET_PRESTAGED);
+  fenix_assert(region != SUBSET_PRESTAGED);
+  fenix_assert(region.max_count() > 0 || region.empty());
+
   region += subset;
+  region.bound(elm_max_count - 1);
 
   int new_count = elm_max_count;
-  if (!new_count) region.max_count();
-  if (!new_count) new_count = subset.max_count();
+  if (!new_count) new_count = region.max_count();
+  fenix_assert(new_count || region.empty());
 
   int new_size = new_count * elm_size;
   if (new_size > buf.size()) buf.resize(new_size);
 }
 
 void Entry::partner_add_and_fit(const DataSubset& subset) {
+  fenix_assert(subset != SUBSET_PRESTAGED);
+  fenix_assert(partner_region != SUBSET_PRESTAGED);
+  fenix_assert(partner_region.max_count() > 0 || partner_region.empty());
+
   partner_region += subset;
+  partner_region.bound(elm_max_count - 1);
 
   int new_count = elm_max_count;
-  if (!new_count) partner_region.max_count();
-  if (!new_count) new_count = subset.max_count();
+  if (!new_count) new_count = partner_region.max_count();
+  fenix_assert(new_count || partner_region.empty());
 
   int new_size = new_count * elm_size;
   if (new_size > partner_buf.size()) partner_buf.resize(new_size);
@@ -192,11 +202,35 @@ void Member::stage(const DataSubset& subset) {
   if (subset == SUBSET_PRESTAGED) FENIX_THROW("Cannot stage SUBSET_PRESTAGED");
 
   Entry& e = entries.back();
-  if (e.elm_max_count == 0 && subset == SUBSET_FULL)
-    FENIX_THROW("Cannot stage SUBSET_FULL to FENIX_RESIZEABLE member");
+  if (e.elm_max_count == 0 && subset == SUBSET_FULL) {
+    // Staging when we don't know the size of the data
+    if (!mentry.serializer) FENIX_THROW(
+      "Cannot stage SUBSET_FULL to non-serializable resizeable member"
+    );
+    
+    // Serializing an unknown sized member takes special care. Use a memstream,
+    // which serves as a dynamically-sized memory-backed file pointer.
+    char* buf   = nullptr;
+    size_t size = 0;
+    FILE* fp    = open_memstream(&buf, &size);
+    fenix_assert(fp != nullptr);
 
-  e.add_and_fit(subset);
-  subset.copy_data(e.elm_size, e.elm_max_count, mentry.user_data, e.buf);
+    // Serialize into the memstream before closing it
+    mentry.serializer(
+      fp, FENIX_SERIALIZE, mentry.user_data, 0, FENIX_RESIZEABLE
+    );
+    fclose(fp);
+
+    // Stage the final data
+    fenix_assert(size % e.elm_size == 0);
+    stage_inplace(buf, DataSubset((size / e.elm_size) - 1));
+  } else {
+    // Normal case staging
+    e.add_and_fit(subset);
+    subset.copy_data(
+      e.elm_size, e.elm_max_count, mentry.user_data, e.buf, mentry.serializer
+    );
+  }
 }
 
 void Member::stage_inplace(void* buf, const DataSubset& subset) {
@@ -208,19 +242,19 @@ void Member::stage_inplace(void* buf, const DataSubset& subset) {
 
   int count = subset.max_count();
   if (subset == SUBSET_FULL) count = e.elm_max_count;
-  else if (count > e.elm_max_count) count = e.elm_max_count;
+  else if (e.elm_max_count && count > e.elm_max_count) count = e.elm_max_count;
 
-  e.buf.take_ownership(buf, count * e.elm_size);
-  e.region = subset;
+  e.buf.take_ownership((char*)buf, count * e.elm_size);
+  e.region = DataSubset({0, count - 1});
 }
 
 tasks::Task<int> Member::istorev(const DataSubset& subset) {
-  if (subset == SUBSET_PRESTAGED) {
-    Entry& e = entries.back();
-    return this->istorev_impl(e.region);
-  } else {
-    stage(subset);
+  if (subset != SUBSET_PRESTAGED) stage(subset);
+
+  if (subset != SUBSET_PRESTAGED && subset != SUBSET_FULL) {
     return this->istorev_impl(subset);
+  } else {
+    return this->istorev_impl(entries.back().region);
   }
 }
 
@@ -238,7 +272,6 @@ tasks::Task<int> BuddyMember::exch(
   recv_buf.reset(e.elm_size * recv_count);
 
   subset.serialize_data(e.elm_size, e.buf, send_buf);
-
   co_await tasks::mpi::sendrecv(
     send_buf.data(), send_buf.size(), MPI_BYTE, right, 0,
     recv_buf.data(), recv_buf.size(), MPI_BYTE,  left, 0,
@@ -263,16 +296,17 @@ tasks::Task<int> BuddyMember::istorev_impl(const DataSubset& subset) {
     if (i == left) co_await recv_buf.recv_unknown(left, 0, group.set_comm);
   }
 
-  co_return co_await exch(subset, DataSubset(recv_buf));
+  DataSubset partner_subset(recv_buf);
+  co_return co_await exch(subset, partner_subset);
 }
 
 tasks::Task<int> Member::istore(const DataSubset& subset) {
-  if (subset == SUBSET_PRESTAGED) {
-    Entry& e = entries.back();
-    return this->istore_impl(e.region);
-  } else {
-    stage(subset);
+  if (subset != SUBSET_PRESTAGED) stage(subset);
+
+  if (subset != SUBSET_PRESTAGED && subset != SUBSET_FULL) {
     return this->istore_impl(subset);
+  } else {
+    return this->istore_impl(entries.back().region);
   }
 }
 
@@ -535,11 +569,12 @@ int Member::lrestore(
   //Restoring always clears the commit buffer
   entries.back().reset();
 
+  // Get index of entry to use
   int end = 0;
   if (timestamp == FENIX_DATA_SNAPSHOT_LATEST) {
-    if (entries[entries.size() - 2].timestamp >= 0) {
-      end = entries.size() - 1;
-    }
+    if (entries[entries.size() - 2].timestamp >= 0) end = entries.size() - 1;
+  } else if (timestamp == FENIX_DATA_SNAPSHOT_ALL) {
+    if (entries[entries.size() - 2].timestamp >= 0) end = entries.size() - 1;
   } else {
     for (int i = entries.size() - 2; i >= 0; i--) {
       if (entries[i].timestamp == timestamp) {
@@ -548,28 +583,28 @@ int Member::lrestore(
       }
     }
   }
+  // If entry not found, error out
+  if (end == 0) FENIX_THROW(FENIX_ERROR_NODATA_FOUND);
 
-  int begin = end > 0 ? end - 1 : end;
-  if (max_restore != 0) {
-    for (
-      int i = end - 1; i >= 0 && !recovered.includes_all(max_restore - 1); i--
-    ) {
-      if (entries[i].timestamp < 0) break;
-      begin = i;
-      recovered += entries[i].region;
+  // Recover the data and report back what was recoverable
+  for (int i = end - 1; i >= 0; i--) {
+    auto& e = entries[i];
+    if (e.timestamp < 0) break;
+
+    if (max_restore > 0) {
+      DataSubset s = e.region - recovered;
+      s.copy_data(e.elm_size, e.buf, max_restore, target, mentry.serializer);
     }
-  } else if (begin < end) {
-    recovered = entries[begin].region;
+
+    recovered += e.region;
+
+    // Only FENIX_DATA_SNAPSHOT_ALL recovers from multiple snapshots
+    if (timestamp != FENIX_DATA_SNAPSHOT_ALL) break;
   }
 
-  for (int i = begin; i < end && target != NULL; i++) {
-    Entry& e = entries[i];
-    e.region.copy_data(e.elm_size, e.buf, max_restore, target);
-  }
-
-  if (end <= 0) FENIX_THROW(FENIX_ERROR_NODATA_FOUND);
-  if (max_restore != 0 && !recovered.includes_all(max_restore - 1))
+  if (max_restore > 0 && !recovered.includes_all(max_restore - 1)) {
     return FENIX_WARNING_PARTIAL_RESTORE;
+  }
   return FENIX_SUCCESS;
 }
 

--- a/src/fenix_data_recovery.cpp
+++ b/src/fenix_data_recovery.cpp
@@ -134,6 +134,15 @@ int member_stage(int groupid, int memberid, const DataSubset& specifier) {
   FENIX_CPP_API_END
 }
 
+int member_stage_inplace(
+  int groupid, int memberid, void* buf, const DataSubset& specifier
+) {
+  FENIX_CPP_API_BEGIN
+  find_group(groupid)->member_stage_inplace(memberid, buf, specifier);
+  return FENIX_SUCCESS;
+  FENIX_CPP_API_END
+}
+
 // Quick little helper function for the 4 kinds of stores
 template <auto Func, typename... Args>
 static int store(int groupid, int memberid, Args&&... args) {

--- a/src/fenix_data_recovery.cpp
+++ b/src/fenix_data_recovery.cpp
@@ -120,6 +120,17 @@ int member_create(
   FENIX_CPP_API_END
 }
 
+int member_create(
+  int groupid, int memberid, void* data, int count, MPI_Datatype datatype,
+  SerializeFileFunc serializer
+) {
+  FENIX_CPP_API_BEGIN
+  return find_group(groupid)->member_create(
+    memberid, data, count, datatype, serializer
+  );
+  FENIX_CPP_API_END
+}
+
 bool member_created(int group_id, int member_id) {
   FENIX_CPP_API_BEGIN
   auto group = search_group(group_id);
@@ -291,6 +302,17 @@ int member_restore(
   DataSubset& data_found
 ) {
   FENIX_CPP_API_BEGIN
+  auto g = find_group(groupid);
+  if (data == FENIX_DATA_RESTORE_INPLACE) {
+    auto m = g->search_member(memberid);
+    if (m) {
+      data = m->user_data;
+    } else if (maxcount > 0) {
+      // Cannot restore this data without knowing where to put it
+      FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
+    }
+  }
+
   data_found = {};
   return find_group(groupid)->member_restore(
     memberid, data, maxcount, timestamp, data_found

--- a/src/fenix_data_recovery.cpp
+++ b/src/fenix_data_recovery.cpp
@@ -60,6 +60,7 @@
 #include "fenix_util.hpp"
 #include "fenix_ext.hpp"
 #include "fenix_data_subset.hpp"
+#include "fenix/data/mstream.hpp"
 
 #include <cassert>
 
@@ -122,7 +123,7 @@ int member_create(
 
 int member_create(
   int groupid, int memberid, void* data, int count, MPI_Datatype datatype,
-  SerializeFileFunc serializer
+  SerializeFunc serializer
 ) {
   FENIX_CPP_API_BEGIN
   return find_group(groupid)->member_create(

--- a/src/fenix_data_recovery.cpp
+++ b/src/fenix_data_recovery.cpp
@@ -132,6 +132,83 @@ int member_create(
   FENIX_CPP_API_END
 }
 
+int member_define(
+  int groupid, int memberid, void* data, int count, MPI_Datatype datatype
+) {
+  FENIX_CPP_API_BEGIN
+  auto group  = find_group(groupid);
+  auto member = group->search_member(memberid);
+  if (!member) {
+    return member_create(groupid, memberid, data, count, datatype);
+  } else {
+    int set;
+    int ret = member_attr_set(
+      groupid, memberid, FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER, data, &set
+    );
+    if (ret == FENIX_SUCCESS)
+      ret = member_attr_set(
+        groupid, memberid, FENIX_DATA_MEMBER_ATTRIBUTE_COUNT, &count, &set
+      );
+    if (ret == FENIX_SUCCESS)
+      ret = member_attr_set(
+        groupid, memberid, FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE, &datatype, &set
+      );
+    member->serializer.reset();
+    return ret;
+  }
+  FENIX_CPP_API_END
+}
+
+int member_define(
+  int groupid, int memberid, void* data, int count, MPI_Datatype datatype,
+  SerializeFunc serializer
+) {
+  FENIX_CPP_API_BEGIN
+  int ret = member_define(groupid, memberid, data, count, datatype);
+  if (ret == FENIX_SUCCESS)
+    find_group(groupid)->find_member(memberid)->serializer.emplace(serializer);
+  return ret;
+  FENIX_CPP_API_END
+}
+
+int member_attr_set(
+  int groupid, int memberid, int attr, void* value, int* flag
+) {
+  FENIX_CPP_API_BEGIN
+  auto group  = find_group(groupid);
+  auto mentry = group->find_member(memberid);
+
+  //Always pass attribute changes along to group - they might have unknown
+  //attributes or side-effects to handle from changes. They get change info
+  //before changes are made, in case they need prior state.
+  int retval = group->member_set_attribute(mentry, attr, value, flag);
+  if (retval != FENIX_SUCCESS) return retval;
+
+  switch (attr) {
+  case FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER:
+    mentry->user_data = (char*)value;
+    break;
+  case FENIX_DATA_MEMBER_ATTRIBUTE_COUNT:
+    mentry->current_count = *((int*)(value));
+    break;
+  case FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE: {
+    MPI_Datatype* dtype = (MPI_Datatype*)value;
+    int dtype_size;
+    int err = MPI_Type_size(*dtype, &dtype_size);
+    if (err) throw RuntimeException("Invalid MPI_Datatype");
+
+    mentry->datatype_size = dtype_size;
+    break;
+  }
+  default:
+    // No problem, since the group policy successfully handled this
+    break;
+  }
+
+  return FENIX_SUCCESS;
+  FENIX_CPP_API_END
+}
+
 bool member_created(int group_id, int member_id) {
   FENIX_CPP_API_BEGIN
   auto group = search_group(group_id);
@@ -373,45 +450,6 @@ int group_delete(int groupid) {
 } // namespace fenix::data
 
 using namespace fenix;
-
-int Fenix_Data_member_attr_set(
-  int groupid, int memberid, int attributename, void* attributevalue, int* flag
-) {
-  FENIX_C_API_BEGIN
-  auto group  = find_group(groupid);
-  auto mentry = group->find_member(memberid);
-
-  //Always pass attribute changes along to group - they might have unknown
-  //attributes or side-effects to handle from changes. They get change info
-  //before changes are made, in case they need prior state.
-  int retval =
-    group->member_set_attribute(mentry, attributename, attributevalue, flag);
-  if (retval != FENIX_SUCCESS) return retval;
-
-  switch (attributename) {
-  case FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER:
-    mentry->user_data = (char*)attributevalue;
-    break;
-  case FENIX_DATA_MEMBER_ATTRIBUTE_COUNT:
-    mentry->current_count = *((int*)(attributevalue));
-    break;
-  case FENIX_DATA_MEMBER_ATTRIBUTE_DATATYPE: {
-    MPI_Datatype* dtype = (MPI_Datatype*)attributevalue;
-    int dtype_size;
-    int err = MPI_Type_size(*dtype, &dtype_size);
-    if (err) throw RuntimeException("Invalid MPI_Datatype");
-
-    mentry->datatype_size = dtype_size;
-    break;
-  }
-  default:
-    // No problem, since the group policy successfully handled this
-    break;
-  }
-
-  return FENIX_SUCCESS;
-  FENIX_C_API_END
-}
 
 int Fenix_Data_group_get_number_of_snapshots(int group_id, int* num_snapshots) {
   FENIX_C_API_BEGIN

--- a/src/fenix_data_subset.cpp
+++ b/src/fenix_data_subset.cpp
@@ -62,6 +62,7 @@
 #include "fenix_data_buffer.hpp"
 
 #include <cstring>
+#include <cstdio>
 
 namespace fenix {
 namespace detail {
@@ -543,7 +544,8 @@ DataSubset DataSubset::operator+(const Fenix_Data_subset& other) const {
 }
 
 DataSubset& DataSubset::operator+=(const DataSubset& other) {
-  fenix_assert(type == BasicSubset && other.type == BasicSubset);
+  fenix_assert(type == BasicSubset);
+  fenix_assert(other.type == BasicSubset);
   *this = *this + other;
   return *this;
 }
@@ -659,6 +661,20 @@ size_t DataSubset::end() const {
   return ret;
 }
 
+DataSubset DataSubset::bounded(size_t max_idx) const {
+  DataSubset ret = {};
+  ret.regions    = bounded_regions(max_idx);
+  return ret;
+}
+
+DataSubset& DataSubset::bound(size_t max_idx) {
+  if (max_idx == MAX) return *this;
+  if (empty()) return *this;
+  if (end() <= max_idx) return *this;
+  regions = bounded_regions(max_idx);
+  return *this;
+}
+
 std::set<DataRegion> DataSubset::bounded_regions(size_t max_idx) const {
   return bounded_regions(0, max_idx);
 }
@@ -667,6 +683,9 @@ std::set<DataRegion> DataSubset::bounded_regions(
   size_t start, size_t end
 ) const {
   fenix_assert(type == BasicSubset);
+  if (empty()) return {};
+  if (this->start() >= start && this->end() <= end) return regions;
+
   std::set<DataRegion> ret;
   DataRegion bounds({start, end});
   for (const auto& r : regions) {
@@ -753,7 +772,8 @@ void DataSubset::deserialize_data(
 }
 
 void DataSubset::copy_data(
-  const size_t elm_size, const size_t src_len, const char* src, DataBuffer& dst
+  const size_t elm_size, const size_t src_len, char* src, DataBuffer& dst,
+  SerializeFileFunc& serializer
 ) const {
   fenix_assert(type == BasicSubset);
   if (regions.empty()) return;
@@ -767,19 +787,34 @@ void DataSubset::copy_data(
   if (dst.size() < (max_elm + 1) * elm_size)
     dst.resize((max_elm + 1) * elm_size);
 
+  FILE* fp;
+  if (serializer) {
+    fp = fmemopen(dst.data(), (max_elm + 1) * elm_size, "w");
+    fenix_assert(fp != nullptr);
+  }
+
   for (const auto& b : BlockIter(bounded_regions(max_elm))) {
     size_t start = b.start * elm_size;
-    size_t len   = (b.end - b.start + 1) * elm_size;
+    size_t count = b.end - b.start + 1;
+    size_t len   = count * elm_size;
 
     fenix_assert(src_len == 0 || (start + len) / elm_size <= src_len);
     fenix_assert(start + len <= dst.size());
 
-    memcpy(dst.data() + start, src + start, len);
+    if (!serializer) {
+      memcpy(dst.data() + start, src + start, len);
+    } else {
+      fseek(fp, start, SEEK_SET);
+      serializer(fp, FENIX_SERIALIZE, src, b.start, count);
+    }
   }
+
+  if (serializer) fclose(fp);
 }
 
 void DataSubset::copy_data(
-  const size_t elm_size, const DataBuffer& src, const size_t dst_len, char* dst
+  const size_t elm_size, DataBuffer& src, const size_t dst_len, char* dst,
+  SerializeFileFunc& serializer
 ) const {
   fenix_assert(type == BasicSubset);
   if (regions.empty()) return;
@@ -791,15 +826,29 @@ void DataSubset::copy_data(
 
   size_t max_elm = std::min(dst_len ? dst_len - 1 : end(), src.size());
 
+  FILE* fp;
+  if (serializer) {
+    fp = fmemopen(src.data(), (max_elm + 1) * elm_size, "r");
+    fenix_assert(fp != nullptr);
+  }
+
   for (const auto& b : BlockIter(bounded_regions(max_elm))) {
     size_t start = b.start * elm_size;
-    size_t len   = (b.end - b.start + 1) * elm_size;
+    size_t count = (b.end - b.start + 1);
+    size_t len   = count * elm_size;
 
     fenix_assert(dst_len == 0 || (start + len) / elm_size <= dst_len);
     fenix_assert(start + len <= src.size());
 
-    memcpy(dst + start, src.data() + start, len);
+    if (!serializer) {
+      memcpy(dst + start, src.data() + start, len);
+    } else {
+      fseek(fp, start, SEEK_SET);
+      serializer(fp, FENIX_DESERIALIZE, dst, b.start, count);
+    }
   }
+
+  if (serializer) fclose(fp);
 }
 
 bool DataSubset::includes(size_t idx) const {

--- a/src/fenix_data_subset.cpp
+++ b/src/fenix_data_subset.cpp
@@ -256,7 +256,8 @@ std::set<DataRegion> DataRegion::operator-(const DataRegion& b) const {
         auto middle_valid  = a.get_rep(1) & inv;
         for (auto block : middle_valid) {
           fenix_assert(!block.reps);
-          mid.insert(DataRegion({block.start, block.end}, a.reps - 2, b.stride)
+          mid.insert(
+            DataRegion({block.start, block.end}, a.reps - 2, b.stride)
           );
         }
       }

--- a/src/fenix_data_subset.cpp
+++ b/src/fenix_data_subset.cpp
@@ -60,6 +60,7 @@
 #include "fenix_util.hpp"
 #include "fenix_data_subset.hpp"
 #include "fenix_data_buffer.hpp"
+#include "fenix/data/mstream.hpp"
 
 #include <cstring>
 #include <cstdio>
@@ -255,8 +256,7 @@ std::set<DataRegion> DataRegion::operator-(const DataRegion& b) const {
         auto middle_valid  = a.get_rep(1) & inv;
         for (auto block : middle_valid) {
           fenix_assert(!block.reps);
-          mid.insert(
-            DataRegion({block.start, block.end}, a.reps - 2, b.stride)
+          mid.insert(DataRegion({block.start, block.end}, a.reps - 2, b.stride)
           );
         }
       }
@@ -771,84 +771,122 @@ void DataSubset::deserialize_data(
   fenix_assert(ptr == src.data() + src.size());
 }
 
-void DataSubset::copy_data(
-  const size_t elm_size, const size_t src_len, char* src, DataBuffer& dst,
-  SerializeFileFunc& serializer
-) const {
-  fenix_assert(type == BasicSubset);
-  if (regions.empty()) return;
+// Returns {bytes_offset, elements_count}
+static inline std::pair<size_t, size_t> get_copy_range(
+  const DataRegion& b, size_t elm_size, size_t byte_max
+) {
+  size_t start = b.start * elm_size;
+  size_t count = b.end - b.start + 1;
+  fenix_assert(start + count * elm_size <= byte_max);
+  return {start, count};
+}
+
+static void copy_impl(
+  const DataSubset* subset, size_t elm_bytes, size_t copy_bytes, char* src,
+  char* dst
+) {
+  size_t max_elm = copy_bytes / elm_bytes - 1;
+  for (const auto& b : BlockIter(subset->bounded_regions(max_elm))) {
+    auto [start, count] = get_copy_range(b, elm_bytes, copy_bytes);
+    memcpy(dst + start, src + start, count * elm_bytes);
+  }
+}
+static void copy_impl(
+  const DataSubset* subset, size_t elm_bytes, size_t copy_bytes, char* src,
+  char* dst, data::SerializeFileFunc& serializer, int dir
+) {
+  const bool deser = dir == FENIX_DESERIALIZE;
+  char* file_buf   = deser ? src : dst;
+  char* user_buf   = deser ? dst : src;
+
+  FILE* fp = fmemopen(file_buf, copy_bytes, deser ? "r" : "w");
+  fenix_assert(fp != nullptr);
+
+  size_t max_elm = copy_bytes / elm_bytes - 1;
+  for (const auto& b : BlockIter(subset->bounded_regions(max_elm))) {
+    auto [start, count] = get_copy_range(b, elm_bytes, copy_bytes);
+    fseek(fp, start, SEEK_SET);
+    serializer(fp, dir, user_buf, b.start, count);
+  }
+
+  fclose(fp);
+}
+static void copy_impl(
+  const DataSubset* subset, size_t elm_bytes, size_t copy_bytes, char* src,
+  char* dst, data::SerializeStreamFunc& serializer, int dir
+) {
+  const bool deser = dir == FENIX_DESERIALIZE;
+  char* strm_buf   = deser ? src : dst;
+  char* user_buf   = deser ? dst : src;
+
+  data::MStream stream(strm_buf, copy_bytes);
+
+  size_t max_elm = copy_bytes / elm_bytes - 1;
+  for (const auto& b : BlockIter(subset->bounded_regions(max_elm))) {
+    auto [offset, count] = get_copy_range(b, elm_bytes, copy_bytes);
+    stream.seekg(offset);
+    stream.seekp(offset);
+    serializer(stream, dir, user_buf, b.start, count);
+  }
+}
+static inline void copy_impl(
+  const DataSubset* sub, size_t e, size_t c, char* sb, char* db,
+  DataSubset::Serializer& s, int dir
+) {
+  if (!s) copy_impl(sub, e, c, sb, db);
+  else if (s->index() == 0)
+    copy_impl(sub, e, c, sb, db, std::get<0>(s.value()), dir);
+  else if (s->index() == 1)
+    copy_impl(sub, e, c, sb, db, std::get<1>(s.value()), dir);
+  else fatal_print("Unknown serializer type %d\n", (int)s->index());
+}
+
+static inline size_t max_copy_bytes(
+  const DataSubset* s, size_t bound_len, size_t elm_bytes
+) {
   fenix_assert(
-    src_len != 0 || end() != MAX,
+    bound_len != 0 || s->end() != DataSubset::MAX,
     "must specify either a maximum element count or provide a limited-bounds "
     "data subset"
   );
-
-  size_t max_elm = src_len ? src_len - 1 : end();
-  if (dst.size() < (max_elm + 1) * elm_size)
-    dst.resize((max_elm + 1) * elm_size);
-
-  FILE* fp;
-  if (serializer) {
-    fp = fmemopen(dst.data(), (max_elm + 1) * elm_size, "w");
-    fenix_assert(fp != nullptr);
-  }
-
-  for (const auto& b : BlockIter(bounded_regions(max_elm))) {
-    size_t start = b.start * elm_size;
-    size_t count = b.end - b.start + 1;
-    size_t len   = count * elm_size;
-
-    fenix_assert(src_len == 0 || (start + len) / elm_size <= src_len);
-    fenix_assert(start + len <= dst.size());
-
-    if (!serializer) {
-      memcpy(dst.data() + start, src + start, len);
-    } else {
-      fseek(fp, start, SEEK_SET);
-      serializer(fp, FENIX_SERIALIZE, src, b.start, count);
-    }
-  }
-
-  if (serializer) fclose(fp);
+  return (bound_len ? bound_len : s->end() + 1) * elm_bytes;
 }
 
 void DataSubset::copy_data(
-  const size_t elm_size, DataBuffer& src, const size_t dst_len, char* dst,
-  SerializeFileFunc& serializer
+  const size_t elm_bytes, const size_t src_len, char* src, DataBuffer& dst,
+  Serializer& s
 ) const {
   fenix_assert(type == BasicSubset);
   if (regions.empty()) return;
-  fenix_assert(
-    dst_len != 0 || end() != MAX,
-    "must specify either a maximum element count or provide a limited-bounds "
-    "data subset"
-  );
 
-  size_t max_elm = std::min(dst_len ? dst_len - 1 : end(), src.size());
+  size_t copy_bytes = max_copy_bytes(this, src_len, elm_bytes);
+  if (dst.size() < copy_bytes) dst.resize(copy_bytes);
 
-  FILE* fp;
-  if (serializer) {
-    fp = fmemopen(src.data(), (max_elm + 1) * elm_size, "r");
-    fenix_assert(fp != nullptr);
-  }
+  copy_impl(this, elm_bytes, copy_bytes, src, dst.data(), s, FENIX_SERIALIZE);
+}
+void DataSubset::copy_data(
+  const size_t elm_size, const size_t src_len, char* src, DataBuffer& dst
+) const {
+  Serializer s = {};
+  copy_data(elm_size, src_len, src, dst, s);
+}
 
-  for (const auto& b : BlockIter(bounded_regions(max_elm))) {
-    size_t start = b.start * elm_size;
-    size_t count = (b.end - b.start + 1);
-    size_t len   = count * elm_size;
+void DataSubset::copy_data(
+  const size_t elm_bytes, DataBuffer& src, const size_t dst_len, char* dst,
+  Serializer& s
+) const {
+  fenix_assert(type == BasicSubset);
+  fenix_assert(src.size() % elm_bytes == 0);
 
-    fenix_assert(dst_len == 0 || (start + len) / elm_size <= dst_len);
-    fenix_assert(start + len <= src.size());
-
-    if (!serializer) {
-      memcpy(dst + start, src.data() + start, len);
-    } else {
-      fseek(fp, start, SEEK_SET);
-      serializer(fp, FENIX_DESERIALIZE, dst, b.start, count);
-    }
-  }
-
-  if (serializer) fclose(fp);
+  size_t copy_bytes =
+    std::min(src.size(), max_copy_bytes(this, dst_len, elm_bytes));
+  copy_impl(this, elm_bytes, copy_bytes, src.data(), dst, s, FENIX_DESERIALIZE);
+}
+void DataSubset::copy_data(
+  const size_t elm_size, DataBuffer& src, const size_t dst_len, char* dst
+) const {
+  Serializer s = {};
+  copy_data(elm_size, src, dst_len, dst, s);
 }
 
 bool DataSubset::includes(size_t idx) const {

--- a/src/logging/message_logging.cpp
+++ b/src/logging/message_logging.cpp
@@ -77,74 +77,41 @@ int sync(int mlog_id, int region_id) {
   FENIX_CPP_API_END
 }
 
-int stage(int mlog_id, int group_id, int member_id) {
-  FENIX_CPP_API_BEGIN
-  using namespace fenix::data;
-  auto mlog  = find_mlog(mlog_id);
-  auto group = find_group(group_id);
-
-  auto member = group->search_member(member_id);
-  if (!member) {
-    member_create(group_id, member_id, nullptr, FENIX_RESIZEABLE, MPI_BYTE);
-    member = group->find_member(member_id);
-  } else if (member->current_count != FENIX_RESIZEABLE) {
-    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-  } else if (member->datatype_size != 1) {
-    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-  }
-
+static void stage_mlog(FILE* fp, int mlog_id) {
+  // TODO: Support a stream-based serializer to improve performance in cases
+  // like this
   std::stringstream o;
-  mlog->serialize(o);
-
-  void* ptr = (void*)o.view().data();
-
-  int flag;
-  Fenix_Data_member_attr_set(
-    group_id, member_id, FENIX_DATA_MEMBER_ATTRIBUTE_BUFFER,
-    (void*)o.view().data(), &flag
-  );
-
-  return member_stage(
-    group_id, member_id, DataSubset(static_cast<int>(o.tellp()) - 1)
-  );
-  FENIX_CPP_API_END
+  find_mlog(mlog_id)->serialize(o);
+  fwrite(o.view().data(), o.view().length(), 1, fp);
 }
 
-int lrestore(int mlog_id, int group_id, int member_id, int time_stamp) {
-  FENIX_CPP_API_BEGIN
-  using namespace fenix::data;
-  auto mlog  = find_mlog(mlog_id);
-  auto group = find_group(group_id);
+static void restore_mlog(FILE* fp, int mlog_id, int nbytes) {
+  std::string buf(static_cast<std::string::size_type>(nbytes), ' ');
+  fread(&buf[0], nbytes, 1, fp);
 
-  auto member = group->find_member(member_id);
-  if (member->current_count != FENIX_RESIZEABLE) {
-    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-  } else if (member->datatype_size != 1) {
-    FENIX_THROW(FENIX_ERROR_INVALID_MEMBERID);
-  }
+  std::stringstream i(std::move(buf));
 
-  DataSubset subset;
-  int ret = group->member_lrestore(member_id, nullptr, 0, time_stamp, subset);
-  if (ret != FENIX_SUCCESS) {
-    throw RuntimeException(ret, "fenix::mlog::lrestore failed");
-  }
+  auto mlog     = find_mlog(mlog_id);
+  auto new_mlog = std::make_shared<CommLog>(mlog->comm, i);
 
-  // Initialize a long enough buffer string
-  int len = subset.max_count();
-  std::string buf(static_cast<std::string::size_type>(len), ' ');
-  ret = group->member_lrestore(member_id, &buf[0], len, time_stamp, subset);
-  if (ret != FENIX_SUCCESS) {
-    throw RuntimeException(ret, "fenix::mlog::lrestore failed");
-  }
-
-  std::istringstream i(std::move(buf));
-  assert(i.view().size() == len);
-
-  auto new_mlog           = std::make_shared<CommLog>(mlog->comm, i);
   fenix_rt.mlogs[mlog_id] = new_mlog;
   if (fenix_rt.active_mlog == mlog) fenix_rt.active_mlog = new_mlog;
+}
 
-  return FENIX_SUCCESS;
+int create_data_member(int mlog_id, int group_id, int member_id) {
+  FENIX_CPP_API_BEGIN
+  return data::member_create(
+    group_id, member_id, nullptr, FENIX_RESIZEABLE, MPI_BYTE,
+    [mlog_id](FILE* fp, int direction, void* buf, int offset, int count) {
+      if (direction == FENIX_SERIALIZE) {
+        fenix_assert(offset == 0 && count == FENIX_RESIZEABLE && !buf);
+        stage_mlog(fp, mlog_id);
+      } else {
+        fenix_assert(offset == 0 && !buf);
+        restore_mlog(fp, mlog_id, count);
+      }
+    }
+  );
   FENIX_CPP_API_END
 }
 

--- a/src/logging/message_logging.cpp
+++ b/src/logging/message_logging.cpp
@@ -79,7 +79,15 @@ int sync(int mlog_id, int region_id) {
 
 int create_data_member(int mlog_id, int group_id, int member_id) {
   FENIX_CPP_API_BEGIN
-  return data::member_create(
+  if (data::find_group(group_id)->search_member(member_id))
+    FENIX_THROW(FENIX_ERROR_MEMBER_EXISTS);
+  return define_data_member(mlog_id, group_id, member_id);
+  FENIX_CPP_API_END
+}
+
+int define_data_member(int mlog_id, int group_id, int member_id) {
+  FENIX_CPP_API_BEGIN
+  return data::member_define(
     group_id, member_id, nullptr, FENIX_RESIZEABLE, MPI_BYTE,
     [mlog_id](
       std::iostream& strm, int direction, void* buf, int offset, int count

--- a/src/logging/message_logging.cpp
+++ b/src/logging/message_logging.cpp
@@ -77,38 +77,23 @@ int sync(int mlog_id, int region_id) {
   FENIX_CPP_API_END
 }
 
-static void stage_mlog(FILE* fp, int mlog_id) {
-  // TODO: Support a stream-based serializer to improve performance in cases
-  // like this
-  std::stringstream o;
-  find_mlog(mlog_id)->serialize(o);
-  fwrite(o.view().data(), o.view().length(), 1, fp);
-}
-
-static void restore_mlog(FILE* fp, int mlog_id, int nbytes) {
-  std::string buf(static_cast<std::string::size_type>(nbytes), ' ');
-  fread(&buf[0], nbytes, 1, fp);
-
-  std::stringstream i(std::move(buf));
-
-  auto mlog     = find_mlog(mlog_id);
-  auto new_mlog = std::make_shared<CommLog>(mlog->comm, i);
-
-  fenix_rt.mlogs[mlog_id] = new_mlog;
-  if (fenix_rt.active_mlog == mlog) fenix_rt.active_mlog = new_mlog;
-}
-
 int create_data_member(int mlog_id, int group_id, int member_id) {
   FENIX_CPP_API_BEGIN
   return data::member_create(
     group_id, member_id, nullptr, FENIX_RESIZEABLE, MPI_BYTE,
-    [mlog_id](FILE* fp, int direction, void* buf, int offset, int count) {
+    [mlog_id](
+      std::iostream& strm, int direction, void* buf, int offset, int count
+    ) {
       if (direction == FENIX_SERIALIZE) {
         fenix_assert(offset == 0 && count == FENIX_RESIZEABLE && !buf);
-        stage_mlog(fp, mlog_id);
+        find_mlog(mlog_id)->serialize(strm);
       } else {
         fenix_assert(offset == 0 && !buf);
-        restore_mlog(fp, mlog_id, count);
+        auto mlog     = find_mlog(mlog_id);
+        auto new_mlog = std::make_shared<CommLog>(mlog->comm, strm);
+
+        fenix_rt.mlogs[mlog_id] = new_mlog;
+        if (fenix_rt.active_mlog == mlog) fenix_rt.active_mlog = new_mlog;
       }
     }
   );

--- a/test/message_replay/replay_test.cpp
+++ b/test/message_replay/replay_test.cpp
@@ -106,6 +106,8 @@ void check_inject_failure(State& state, int app_ranks) {
 }
 
 int main(int argc, char** argv) {
+  namespace data = fenix::data;
+  namespace mlog = fenix::mlog;
   using namespace fenix::data;
   MPI_Init(&argc, &argv);
 
@@ -116,7 +118,7 @@ int main(int argc, char** argv) {
 
   // Hold on to checkpoint_iterations * 2 regions at once, to be sure we can
   // replay any failed rank's collective messages
-  fenix::mlog::create(mlogs, res_world, checkpoint_iterations * 2);
+  mlog::create(mlogs, res_world, checkpoint_iterations * 2);
 
   // Grab basic MPI info
   int n_ranks, rank;
@@ -133,21 +135,27 @@ int main(int argc, char** argv) {
     state.rank      = rank;
     state.iteration = 0;
 
-    fenix::data::group_create(group);
-    fenix::data::member_create(group, state_member, &state, 2, MPI_INT);
-    fenix::data::member_stage(group, state_member);
-    fenix::mlog::stage(mlogs, group, mlogs_member);
-    fenix::data::member_store(group, SUBSET_PRESTAGED);
-    fenix::data::commit_barrier(group);
+    data::group_create(group);
+    data::member_create(group, state_member, &state, 2, MPI_INT);
+    mlog::create_data_member(mlogs, group, mlogs_member);
+
+    data::member_store(group);
+    data::commit_barrier(group);
   } else {
     // Recovered ranks just recover from the checkpoint instead
     while (true) {
       try {
-        fenix::data::group_create(group);
-        fenix::data::member_restore(group, state_member, &state, 2);
-        fenix::data::member_restore(group, mlogs_member, nullptr, 0);
-        fenix::mlog::lrestore(mlogs, group, mlogs_member);
-        fenix::mlog::sync(mlogs, state.iteration);
+        data::group_create(group);
+
+        if (!data::member_created(group, state_member))
+          data::member_create(group, state_member, &state, 2, MPI_INT);
+        data::member_restore(group, state_member);
+
+        if (!data::member_created(group, mlogs_member))
+          mlog::create_data_member(mlogs, group, mlogs_member);
+        data::member_restore(group, mlogs_member);
+
+        mlog::sync(mlogs, state.iteration);
       } catch (fenix::CommException& error) {
         continue;
       }
@@ -166,9 +174,9 @@ int main(int argc, char** argv) {
   fenix::callback_register([&](MPI_Comm repaired_comm, int mpi_err) {
     assert(fenix::error() == FENIX_SUCCESS);
 
-    fenix::data::group_create(group);
-    fenix::data::member_restore(group, state_member, NULL, 0);
-    fenix::data::member_restore(group, mlogs_member, NULL, 0);
+    data::group_create(group);
+    data::member_restore(group, state_member, NULL, 0);
+    data::member_restore(group, mlogs_member, NULL, 0);
 
     printf(
       "Rank %d continuing inline at iteration %d\n", state.rank, state.iteration
@@ -180,7 +188,7 @@ int main(int argc, char** argv) {
     check_inject_failure(state, n_ranks);
 
     // Enable logging on mlogs and start region i
-    fenix::mlog::activate(mlogs, i);
+    mlog::activate(mlogs, i);
 
 #ifdef FENIX_STENCIL_ENABLE_BARRIERS
     if (i % barrier_iterations == 0) {
@@ -236,11 +244,9 @@ int main(int argc, char** argv) {
     std::this_thread::sleep_for(std::chrono::milliseconds(iteration_work_ms));
 
     if (state.iteration % checkpoint_iterations == 0) {
-      fenix::data::member_stage(group, state_member);
-      fenix::mlog::stage(mlogs, group, mlogs_member);
       // With an active log and inline recovery enabled, checkpoint will
       // recover inline automatically.
-      fenix::data::checkpoint(group, SUBSET_PRESTAGED, {mlogs_member});
+      data::checkpoint(group, SUBSET_FULL, {mlogs_member});
     }
   }
 

--- a/test/subset/subset_copy.cpp
+++ b/test/subset/subset_copy.cpp
@@ -34,11 +34,11 @@
 //
 // THIS SOFTWARE IS PROVIDED BY RUTGERS UNIVERSITY and SANDIA CORPORATION
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL RUTGERS 
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL RUTGERS
 // UNIVERISY, SANDIA CORPORATION OR THE CONTRIBUTORS BE LIABLE FOR ANY
 // DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
 // GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
 // IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
@@ -62,6 +62,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <iostream>
 
 #include <fenix_data_subset.hpp>
 
@@ -69,45 +70,68 @@
 
 using namespace fenix;
 
-bool test_copy(const DataSubset& a){
-   size_t count = a.max_count();
-   if(count == 0) count = 1000;
-
-   std::vector<int> in, out;
-   in.resize(count);
-   out.resize(count);
-
-   DataBuffer buf;
-
-   for(int& i : in) i = 1;
-   for(int& i : out) i = 0;
-
-   a.copy_data(sizeof(int), count, (char*)in.data(), buf);
-   a.copy_data(sizeof(int), buf, count, (char*)out.data());
-
-   for(int i = 0; i < count; i++){
-      if(a.includes(i) && out[i] != 1){
-         printf("Failed to transfer index %d\n", i);
-         return false;
-      } else if(!a.includes(i) && out[i] != 0){
-         printf("Incorrectly transfered index %d\n", i);
-         return false;
-      }
-   }
-   
-   return true;
+void file_serializer(FILE* fp, int direction, void* b, int offset, int count) {
+  int* buf = (int*)b;
+  if (direction == FENIX_SERIALIZE) {
+    fwrite(buf + offset, sizeof(int), count, fp);
+  } else {
+    fread(buf + offset, sizeof(int), count, fp);
+  }
 }
 
-int main(int argc, char **argv)
-{
-   bool success = true;
-
-   auto subsets = get_subsets();
-   for(const auto& a : subsets){
-      success &= test_copy(a);
-   }
-
-   return success ? 0 : 1;
+void stream_serializer(
+  std::iostream& s, int direction, void* b, int offset, int count
+) {
+  int* buf = (int*)b;
+  if (direction == FENIX_SERIALIZE) {
+    s.write((char*)(buf + offset), sizeof(int) * count);
+  } else {
+    s.read((char*)(buf + offset), sizeof(int) * count);
+  }
 }
 
+bool test_copy(const DataSubset& a, DataSubset::Serializer s = {}) {
+  size_t count = a.max_count();
+  if (count == 0) count = 1000;
 
+  std::vector<int> in, out;
+  in.resize(count);
+  out.resize(count);
+
+  DataBuffer buf;
+
+  for (int& i : in) i = 1;
+  for (int& i : out) i = 0;
+
+  a.copy_data(sizeof(int), count, (char*)in.data(), buf);
+  a.copy_data(sizeof(int), buf, count, (char*)out.data());
+
+  for (int i = 0; i < count; i++) {
+    if (a.includes(i) && out[i] != 1) {
+      printf("Failed to transfer index %d\n", i);
+      return false;
+    } else if (!a.includes(i) && out[i] != 0) {
+      printf("Incorrectly transfered index %d\n", i);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+int main(int argc, char** argv) {
+  bool success = true;
+
+  auto subsets = get_subsets();
+  for (const auto& a : subsets) {
+    success &= test_copy(a);
+  }
+  for (const auto& a : subsets) {
+    success &= test_copy(a, file_serializer);
+  }
+  for (const auto& a : subsets) {
+    success &= test_copy(a, stream_serializer);
+  }
+
+  return success ? 0 : 1;
+}

--- a/test/subset/subset_copy.cpp
+++ b/test/subset/subset_copy.cpp
@@ -111,7 +111,7 @@ bool test_copy(const DataSubset& a, DataSubset::Serializer s = {}) {
       printf("Failed to transfer index %d\n", i);
       return false;
     } else if (!a.includes(i) && out[i] != 0) {
-      printf("Incorrectly transfered index %d\n", i);
+      printf("Incorrectly transferred index %d\n", i);
       return false;
     }
   }


### PR DESCRIPTION
Add option to stage by taking ownership of a buffer.

Add serializable data members that are staged/restored by invoking a serialize function. Serializable data members that are also resizeable can be staged as SUBSET_FULL - the amount of data staged is determined by the amount serialized.

Serializable data members must be recreated before being restored, else the serialization function is not set up correctly. Users can either null-restore, then redefine the member, then lrestore, or then can just define the member before restoring.~I'll need to support adding or changing a member's serializer sometime in the future.~

Restoring a data member can now be done to FENIX_DATA_RESTORE_INPLACE, which is translated internally to whatever the member's buffer is currently configured as. Restoring data members can now be done with size set to FENIX_DATA_RESTORE_FULL, which assumes the data buffer is large enough to hold whatever data is available to be restored. The combination of these should make it easy to support FENIX_DATA_MEMBER_ALL, but I haven't done so yet (I'm undecided on the semantics for the "restored data" subset that is returned).